### PR TITLE
Fix SQL issue when using 'IS NOT NULL'

### DIFF
--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -472,8 +472,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
     case '!':
     case 'not':
       if(value === null) {
-        this.query += 'IS NOT NULL';
-        return;
+        str = 'IS NOT NULL';
       }
       else {
         // For array values, do a "NOT IN"


### PR DESCRIPTION
```
Model.find({
    attribute: {
        '!': null
    }
}); 
```

is currently broken (produces invalid SQL). This fixes it.
