### PR TITLE
use columnName if defined in model

### DIFF
--- a/sequel/where.js
+++ b/sequel/where.js
@@ -205,7 +205,7 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
 
         _.keys(self.schema[populationAlias].attributes).forEach(function(attr) {
           if(!hop(self.schema[populationAlias].attributes[attr], 'primaryKey')) return;
-          childPK = attr;
+          childPK = self.schema[populationAlias].attributes[attr].columnName || attr;
         });
 
         population.criteria.sort = {};


### PR DESCRIPTION
I had an issue where the attribute name was being used instead of the columnName defined for it. 

SQL generated pointed to `fieldName` instead of `field_name` as defined in the model.
