### PR TITLE
Fixes #10 - INSERT statements broken

### DIFF
--- a/sequel/lib/utils.js
+++ b/sequel/lib/utils.js
@@ -74,7 +74,7 @@ utils.mapAttributes = function(data, options) {
       params.push('$' + i);
     }
     else {
-      if(value === null) {
+      if(value === null || value === undefined) {
         params.push('null');
       }
       else {


### PR DESCRIPTION
The problem is that we are using === to check if the value is null
when we really want to know if the attribute is null or undefined.  This
fix uses type coercion to our advantage.
