### PR TITLE
fix for empty NOT IN () in WHERE clause

### DIFF
--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -334,6 +334,12 @@ CriteriaProcessor.prototype.process = function process(parent, value, combinator
         _param = utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(parent, self.escapeCharacter);
       }
 
+      // Check for an empty array to avoid issues with NOT IN ()
+      if ((key === '!' || key === 'not') && Array.isArray(obj[key]) && obj[key].length === 0) {
+        self.queryString += 'TRUE AND ';
+        return;
+      }
+
       self.queryString += _param + ' ';
       self.prepareCriterion(key, obj[key]);
       self.queryString += ' AND ';


### PR DESCRIPTION
The following code gives an error for trying to do an empty NOT IN (), which is invalid SQL.

```
var list = [];
User.find().where({id: {not: list}}).exec(function (err, users) {
});
```

I added a small fix to use WHERE TRUE instead when this occurs.
