### PR TITLE
sql viaJunctor changed so no duplicate rows are returned

### DIFF
--- a/sequel/where.js
+++ b/sequel/where.js
@@ -222,7 +222,7 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
 
         // If where criteria was used append an AND clause
         if(population.criteria.where && _.keys(population.criteria.where).length > 0) {
-          queryString += 'AND ';
+          queryString += ' WHERE ';
         }
 
         queryString += parsedCriteria.query;


### PR DESCRIPTION
This should solve balderdashy/sails-postgresql#116

Postgresql is not the only affected adapter, the mysql adapter will benefit from this patch too.
