### PR TITLE
Making the schema matching for case insensitivity more flexible.

### DIFF
--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -192,7 +192,11 @@ CriteriaProcessor.prototype.like = function like(val) {
     var caseSensitive = true;
 
     // Check if parent is a string, if so make sure it's case sensitive.
-    if(self.currentSchema[parent] && self.currentSchema[parent].type === 'text') {
+    if(self.currentSchema[parent] &&
+        (self.currentSchema[parent] === 'text' ||
+         self.currentSchema[parent] === 'string' ||
+         self.currentSchema[parent].type === 'string' ||
+         self.currentSchema[parent].type === 'text')) {
       caseSensitive = false;
     }
 
@@ -326,7 +330,11 @@ CriteriaProcessor.prototype.process = function process(parent, value, combinator
       }
 
       // Check if key is a string
-      if(self.currentSchema[parent] && self.currentSchema[parent].type === 'text') {
+      if (self.currentSchema[parent] && 
+           (self.currentSchema[parent].type === 'text' ||
+            self.currentSchema[parent].type === 'string' ||
+            self.currentSchema[parent] === 'string' ||
+            self.currentSchema[parent] === 'text')) {
         lower = true;
       }
 
@@ -361,7 +369,11 @@ CriteriaProcessor.prototype.process = function process(parent, value, combinator
   var lower = false;
 
   // Check if parent is a number or anything that can't be lowercased
-  if(self.currentSchema[parent] && self.currentSchema[parent].type === 'text') {
+  if(self.currentSchema[parent] && 
+      (self.currentSchema[parent] === 'text' ||
+       self.currentSchema[parent] === 'string' ||
+       self.currentSchema[parent].type === 'string' ||
+       self.currentSchema[parent].type === 'text')) {
     lower = true;
   }
 


### PR DESCRIPTION
The checks for text/string fields were incomplete when building case insensitive queries. In a few spots the schema checks were checking for a type = 'text', but were not checking for the other equivalent (given a pg backend) permutations.

For example, given the following set of attributes, only the fourth would be treated in a case insensitive manner for an equality check. The others would be treated in a case sensitive manner.

``` javascript
    // 1
    firstName: {
      type: 'string',
      required: true
    },
    // 2
    lastName: 'string',
    // 3
    address: 'text',
    // 4
    address2: {
      type: 'text',
      required: true
    }
```

I found this while working through some of the failing sails-postgres integration tests
