### PR TITLE
Replacing a this.caseSensitive with self.caseSensitive.

### DIFF
--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -200,7 +200,7 @@ CriteriaProcessor.prototype.like = function like(val) {
       caseSensitive = false;
     }
 
-    var comparator = this.caseSensitive ? 'ILIKE' : 'LIKE';
+    var comparator = self.caseSensitive ? 'ILIKE' : 'LIKE';
 
     self.process(parent, val[parent], comparator, caseSensitive);
     self.queryString += ' AND ';


### PR DESCRIPTION
In the `expandBlock` function, `this.caseSensitive` is not set. `self.caseSensitive` (used elsewhere in the function) is set correctly.

This corrects the ILIKE unit test failures described in balderdashy/sails-postgresql#124 (failures 5 & 6). Integration tests for sails-mysql and sails-postgresql both still succeed with this change.
