### PR TITLE
Keep milliseconds when converting date objects to a SQL-friendly format

### DIFF
--- a/sequel/lib/utils.js
+++ b/sequel/lib/utils.js
@@ -153,5 +153,14 @@ utils.escapeString = function(value) {
  */
 
 utils.toSqlDate = function(date) {
-  return date.toUTCString();
+  utc = new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds(),
+    date.getUTCMilliseconds()
+  );
+  return utc.toISOString();
 };


### PR DESCRIPTION
Currently timestamps cannot be stored w/ millisecond precision. See: https://github.com/balderdashy/sails-postgresql/issues/105, https://github.com/balderdashy/waterline/issues/624, both of which were closed due to the actual issue not residing in those modules.

I don't see an issue opened in `waterline-sequel` regarding this but I believe that this is the module responsible for the bug.

`toUTCString()` drops milliseconds whereas `toISOString()` doesn't. I've switched to using `toISOString` on the UTC date (couldn't find another way to get at it aside from manually building one piece at a time -- open to suggestions).

It's worth noting that `toUTCString()` and `toISOString()` produce different outputs. Postgres, anyways, is cool with either. Although seemingly unlikely, it's possible that other database won't be okay with an ISO8601-formatted timestamp (the output of `toISOString()`).