### PR TITLE
#25: WhereBuilder.single returns incorrect data type if no queryObject given

### DIFF
--- a/sequel/where.js
+++ b/sequel/where.js
@@ -79,7 +79,10 @@ var WhereBuilder = module.exports = function WhereBuilder(schema, currentTable, 
 
 WhereBuilder.prototype.single = function single(queryObject, options) {
 
-  if(!queryObject) return '';
+  if(!queryObject) return {
+	query: '',
+	values: []
+  };
 
   var self = this;
   var queryString = '';


### PR DESCRIPTION
This fixes the bug I experienced where WhereBuilder can return a string instead of an object and confuse calling code.  I think there might be more cases like this in the where builders.