### PR TITLE
Feature/filter by children

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waterline-sequel",
   "description": "A helper library for generating SQL queries from the Waterline Query Language.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "Cody Stoltman <particlebanana@gmail.com>",
   "url": "http://github.com/balderdashy/waterline-sequel",
   "keywords": [],

--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -21,6 +21,7 @@ var CriteriaProcessor = module.exports = function CriteriaProcessor(currentTable
   this.currentTable = currentTable;
   this.schema = schema;
   this.currentSchema = schema[currentTable].attributes;
+  this.tableScope = null;
   this.queryString = '';
   this.values = [];
   this.paramCount = 1;

--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -490,7 +490,7 @@ CriteriaProcessor.prototype.processObject = function processObject (tableName, p
 
       // Check if value is a string and if so add LOWER logic
       // to work with case in-sensitive queries
-      self.queryString += self.buildParam(self.getTableAlias(), parent, !sensitive && _.isString(obj[key]) && lower);
+      self.queryString += self.buildParam(self.getTableAlias(), parent, !sensitive && _.isString(obj[key]) && lower) + ' ';
       self.prepareCriterion(key, obj[key]);
       self.queryString += ' AND ';
     });

--- a/sequel/lib/utils.js
+++ b/sequel/lib/utils.js
@@ -44,6 +44,18 @@ utils.escapeName = function escapeName(name, escapeCharacter) {
 };
 
 /**
+ * Populate alias. Create the alias for an association
+ *
+ * @param {string} alias
+ *
+ * @returns {string}
+ */
+
+utils.populationAlias = function (alias) {
+  return '__' + alias;
+};
+
+/**
  * Map Attributes
  *
  * Takes a js object and creates arrays used for parameterized

--- a/sequel/where.js
+++ b/sequel/where.js
@@ -90,15 +90,16 @@ WhereBuilder.prototype.single = function single(queryObject, options) {
 
     var strategy = queryObject.instructions[attr].strategy.strategy;
     var population = queryObject.instructions[attr].instructions[0];
+    var alias = utils.escapeName(utils.populationAlias(population.alias), self.escapeCharacter);
 
     var parentAlias = _.find(_.values(self.schema), {tableName: population.parent}).identity;
     // Handle hasFK
     if(strategy === 1) {
 
       // Set outer join logic
-      queryString += 'LEFT OUTER JOIN ' + utils.escapeName(population.child, self.escapeCharacter) + ' AS ' + utils.escapeName('__'+population.alias, self.escapeCharacter) + ' ON ';
+      queryString += 'LEFT OUTER JOIN ' + utils.escapeName(population.child, self.escapeCharacter) + ' AS ' + alias + ' ON ';
       queryString += utils.escapeName(parentAlias, self.escapeCharacter) + '.' + utils.escapeName(population.parentKey, self.escapeCharacter);
-      queryString += ' = ' + utils.escapeName('__'+population.alias, self.escapeCharacter) + '.' + utils.escapeName(population.childKey, self.escapeCharacter);
+      queryString += ' = ' + alias + '.' + utils.escapeName(population.childKey, self.escapeCharacter);
 
       addSpace = true;
     }

--- a/test/queries/complexSelectNestedFilters.js
+++ b/test/queries/complexSelectNestedFilters.js
@@ -1,0 +1,96 @@
+module.exports = {
+  // A description. This is used for display in the test output.
+  description: 'Should construct a complex, nested filter select query',
+
+  // The name of the table this query should be ran against.
+  table      : 'foo',
+
+  // The query object used to build this query.
+  query      : {
+    where         : {
+      or : [
+        {color: "red"},
+        {color: "blue"},
+        {color: "grey"},
+        {
+          bat: {
+            color_g: "yellow"
+          }
+        },
+        {
+          bat: {
+            color_g: "blue"
+          }
+        }
+      ],
+      bat: {
+        color_h: "red",
+        or     : [
+          {
+            "color_i": [
+              "pink",
+              "purple",
+              "green"
+            ]
+          },
+          {
+            color_i: {
+              ">": "black"
+            }
+          },
+          {
+            color_i: "yellow"
+          }
+        ]
+      }
+    },
+    instructions: {
+      bat: {
+        strategy    : {
+          strategy: 1,
+          meta    : {
+            parentFK: "bat"
+          }
+        },
+        instructions: [
+          {
+            parent         : "foo",
+            parentKey      : "bat",
+            child          : "bat",
+            childKey       : "id",
+            select         : ["color_g", "color_h", "color_i", "id", "createdAt", "updatedAt"],
+            alias          : "bat",
+            removeParentKey: true,
+            model          : true,
+            collection     : false,
+            criteria       : {"where": {}}
+          }
+        ]
+      }
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz`, `__bat`.`color_g` AS `bat___color_g`, `__bat`.`color_h` AS `bat___color_h`, `__bat`.`color_i` AS `bat___color_i`, `__bat`.`id` AS `bat___id`, `__bat`.`createdAt` AS `bat___createdAt`, `__bat`.`updatedAt` AS `bat___updatedAt` FROM `foo` AS `foo` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz`, `__bat`.`color_g` AS `bat___color_g`, `__bat`.`color_h` AS `bat___color_h`, `__bat`.`color_i` AS `bat___color_i`, `__bat`.`id` AS `bat___id`, `__bat`.`createdAt` AS `bat___createdAt`, `__bat`.`updatedAt` AS `bat___updatedAt` FROM `foo` AS `foo`  LEFT OUTER JOIN `bat` AS `__bat` ON `foo`.`bat` = `__bat`.`id` WHERE ((LOWER(`foo`.`color`) = "red") OR (LOWER(`foo`.`color`) = "blue") OR (LOWER(`foo`.`color`) = "grey") OR (`__bat`.`color_g` = "yellow" ) OR (`__bat`.`color_g` = "blue" )) AND `__bat`.`color_h` = "red" AND ((`__bat`.`color_i` IN ("pink","purple","green")) OR (`__bat`.`color_i` > "black" ) OR (`__bat`.`color_i` = "yellow"))  ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    }
+  }
+};

--- a/test/queries/simpleSelectNestedFilters.js
+++ b/test/queries/simpleSelectNestedFilters.js
@@ -1,0 +1,65 @@
+module.exports = {
+  // A description. This is used for display in the test output.
+  description: 'Should construct a simple nested filter select query',
+
+  // The name of the table this query should be ran against.
+  table      : 'foo',
+
+  // The query object used to build this query.
+  query      : {
+    where       : {
+      bat  : {
+        color_g: "yellow"
+      },
+      color: "red"
+    },
+    instructions: {
+      bat: {
+        strategy    : {
+          strategy: 1,
+          meta    : {
+            parentFK: "bat"
+          }
+        },
+        instructions: [
+          {
+            parent         : "foo",
+            parentKey      : "bat",
+            child          : "bat",
+            childKey       : "id",
+            select         : ["color_g", "color_h", "color_i", "id", "createdAt", "updatedAt"],
+            alias          : "bat",
+            removeParentKey: true,
+            model          : true,
+            collection     : false,
+            criteria       : {where: {}}
+          }
+        ]
+      }
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz`, `__bat`.`color_g` AS `bat___color_g`, `__bat`.`color_h` AS `bat___color_h`, `__bat`.`color_i` AS `bat___color_i`, `__bat`.`id` AS `bat___id`, `__bat`.`createdAt` AS `bat___createdAt`, `__bat`.`updatedAt` AS `bat___updatedAt` FROM `foo` AS `foo` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz`, `__bat`.`color_g` AS `bat___color_g`, `__bat`.`color_h` AS `bat___color_h`, `__bat`.`color_i` AS `bat___color_i`, `__bat`.`id` AS `bat___id`, `__bat`.`createdAt` AS `bat___createdAt`, `__bat`.`updatedAt` AS `bat___updatedAt` FROM `foo` AS `foo`  LEFT OUTER JOIN `bat` AS `__bat` ON `foo`.`bat` = `__bat`.`id` WHERE `__bat`.`color_g` = "yellow"  AND LOWER(`foo`.`color`) = "red" ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    }
+  }
+};


### PR DESCRIPTION
Allow filtering parent resultset by child criteria. 
Provides the requested functionalities from [#597](https://github.com/balderdashy/waterline/issues/597), [#645](https://github.com/balderdashy/waterline/issues/645), [#2238](https://github.com/balderdashy/sails/issues/2238), [#48](https://github.com/balderdashy/sails-redis/issues/48) and [#2392](https://github.com/balderdashy/sails/issues/2392)

I've implemented a couple of additional methods, as well of the concept of scoping.

Scoping the current criteriaParser to a different (association) table will allow expanding of criteria to said associations. By using a scope, it will also automatically assume you're talking about a population, and create the alias.

**Notes:**
- This doesn't work if you don't populate the model you're filtering because the alias of the join table won't exist.
- It treats children differently from criteria (as it should) and doesn't alter the default behavior.

~~Works, except for missing passing of `currentTable`.  I made a booboo in the code (`parentSchema = this.schema[parent]`, which won't work for properties obviously.). This has one single side effect, being that case sensitivity detection doesn't work.~~

~~I'll have to refactor by either changing and restoring the current scopes (currentTable, currentSchema etc) or by passing along the table (association) we're expanding for.~~

~~The reason I haven't implemented this yet is because I'm not sure if you'll approve of my approach :) Also, I'm about to head out for some meetings and just wanted to put this out there for the feedback.~~

``` javascript
  sails.models.foo.find({
    or : [
      {
        color: 'red'
      },
      {
        color: 'blue'
      },
      {
        color: 'grey'
      },
      {
        bat : {
          color_g : 'yellow'
        }
      },
      {
        bat : {
          color_g : 'blue'
        }
      }
    ],
    bat : {
      color_h : 'red', // red
      or : [
        {
          color_i : ['pink', 'purple', 'green']
        },
        {
          color_i : {
            '>' : 'black'
          }
        },
        {
          color_i: 'yellow'
        }
      ]
    }
  }).populate('bat').exec(function (error, data) {
    if (error) {
      return console.log(error);
    }

    console.log(data);
  });
};
```

Nicely creates:

``` sql
SELECT 
    `foo`.`color`,
    `foo`.`id`,
    `foo`.`createdAt`,
    `foo`.`updatedAt`,
    `foo`.`bar`,
    `foo`.`bat`,
    `foo`.`baz`,
    `__bat`.`color_g` AS `bat___color_g`,
    `__bat`.`color_h` AS `bat___color_h`,
    `__bat`.`color_i` AS `bat___color_i`,
    `__bat`.`id` AS `bat___id`,
    `__bat`.`createdAt` AS `bat___createdAt`,
    `__bat`.`updatedAt` AS `bat___updatedAt`
FROM
    `foo` AS `foo`
        LEFT OUTER JOIN
    `bat` AS `__bat` ON `foo`.`bat` = `__bat`.`id`
WHERE
    ((`foo`.`color` = 'red')
        OR (`foo`.`color` = 'blue')
        OR (`foo`.`color` = 'grey')
        OR (`__bat`.`color_g` = 'yellow')
        OR (`__bat`.`color_g` = 'blue'))
        AND `__bat`.`color_h` = 'red'
        AND ((`__bat`.`color_i` IN ('pink' , 'purple', 'green'))
        OR (`__bat`.`color_i` > 'black')
        OR (`__bat`.`color_i` = 'yellow'))
```
