### PR TITLE
Modified code to support ANSI_QUOTES enabled servers

### DIFF
--- a/sequel/lib/cast.js
+++ b/sequel/lib/cast.js
@@ -1,7 +1,7 @@
 /**
  * Cast special values to proper types.
  *
- * Ex: Array is stored as "[0,1,2,3]" and should be cast to proper
+ * Ex: Array is stored as '[0,1,2,3]' and should be cast to proper
  * array for return values.
  */
 
@@ -27,7 +27,7 @@ Query.prototype.cast = function(values) {
 
 Query.prototype.castValue = function(key, value, attributes, schema, joinKey) {
 
-  // Check if key is a special "join" key, identified with a '__' split
+  // Check if key is a special 'join' key, identified with a '__' split
   var attr = key.split('__');
   if(attr.length === 2) {
 
@@ -38,7 +38,7 @@ Query.prototype.castValue = function(key, value, attributes, schema, joinKey) {
     }
   }
 
-  // Lookup Schema "Type"
+  // Lookup Schema 'Type'
   if(!schema[key]) return;
   var type = schema[key].type;
   if(!type) return;

--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -27,7 +27,8 @@ var CriteriaProcessor = module.exports = function CriteriaProcessor(currentTable
   this.paramCount = 1;
   this.parameterized = true;
   this.caseSensitive = true;
-  this.escapeCharacter = '"';
+  this.escapeCharacter = "'";
+  this.identifierCharacter = '`';
   this.wlNext = {};
 
   if(options && utils.object.hasOwnProperty(options, 'parameterized')) {
@@ -40,6 +41,10 @@ var CriteriaProcessor = module.exports = function CriteriaProcessor(currentTable
 
   if(options && utils.object.hasOwnProperty(options, 'escapeCharacter')) {
     this.escapeCharacter = options.escapeCharacter;
+  }
+
+  if(options && utils.object.hasOwnProperty(options, 'identifierCharacter')) {
+    this.identifierCharacter = options.identifierCharacter;
   }
 
   if(options && utils.object.hasOwnProperty(options, 'paramCount')) {
@@ -284,13 +289,13 @@ CriteriaProcessor.prototype._in = function _in(key, val) {
   // Check case sensitivity to decide if LOWER logic is used
   if(!caseSensitivity) {
     if(lower) {
-      key = 'LOWER(' + utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(key, self.escapeCharacter) + ')';
+      key = 'LOWER(' + utils.escapeName(self.currentTable, self.identifierCharacter) + '.' + utils.escapeName(key, self.identifierCharacter) + ')';
     } else {
-      key = utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(key, self.escapeCharacter);
+      key = utils.escapeName(self.currentTable, self.identifierCharacter) + '.' + utils.escapeName(key, self.identifierCharacter);
     }
     self.queryString += key + ' IN (';
   } else {
-    self.queryString += utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(key, self.escapeCharacter) + ' IN (';
+    self.queryString += utils.escapeName(self.currentTable, self.identifierCharacter) + '.' + utils.escapeName(key, self.identifierCharacter) + ' IN (';
   }
 
   // Append each value to query
@@ -308,7 +313,7 @@ CriteriaProcessor.prototype._in = function _in(key, val) {
     }
     else {
       if(_.isString(value)) {
-        value = '"' + utils.escapeString(value) + '"';
+        value = utils.stringLiteral(value, self.escapeCharacter);
       }
 
       self.queryString += value + ',';
@@ -367,10 +372,10 @@ CriteriaProcessor.prototype.process = function process(parent, value, combinator
       // Check if value is a string and if so add LOWER logic
       // to work with case in-sensitive queries
       if(!caseSensitive && _.isString(obj[key]) && lower) {
-        _param = 'LOWER(' + utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(parent, self.escapeCharacter) + ')';
+        _param = 'LOWER(' + utils.escapeName(self.currentTable, self.identifierCharacter) + '.' + utils.escapeName(parent, self.identifierCharacter) + ')';
         obj[key] = obj[key].toLowerCase();
       } else {
-        _param = utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(parent, self.escapeCharacter);
+        _param = utils.escapeName(self.currentTable, self.identifierCharacter) + '.' + utils.escapeName(parent, self.identifierCharacter);
       }
 
       self.queryString += _param + ' ';
@@ -408,12 +413,12 @@ CriteriaProcessor.prototype.process = function process(parent, value, combinator
   if(!caseSensitive && lower && _.isString(value)) {
 
     // ADD LOWER to parent
-    parent = 'LOWER(' + utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(parent, self.escapeCharacter) + ')';
+    parent = 'LOWER(' + utils.escapeName(self.currentTable, self.identifierCharacter) + '.' + utils.escapeName(parent, self.identifierCharacter) + ')';
     value = value.toLowerCase();
 
   } else {
     // Escape parent
-    parent = utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(parent, self.escapeCharacter);
+    parent = utils.escapeName(self.currentTable, self.identifierCharacter) + '.' + utils.escapeName(parent, self.identifierCharacter);
   }
 
   if(value !== null) {
@@ -435,7 +440,7 @@ CriteriaProcessor.prototype.process = function process(parent, value, combinator
       }
 
       if (_.isString(value)) {
-        value = '"' + utils.escapeString(value) +'"';
+        value = utils.stringLiteral(value, self.escapeCharacter);
       }
 
       this.queryString += parent + ' ' + combinator + ' ' + value;
@@ -469,7 +474,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       ('00' + value.getMinutes()).slice(-2) + ':' +
       ('00' + value.getSeconds()).slice(-2);
 
-    value = '"' + value + '"';
+    value = utils.stringLiteral(value, self.escapeCharacter);
     escapedDate = true;
   }
 
@@ -484,7 +489,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
       else {
         if(_.isString(value) && !escapedDate) {
-          value = '"' + utils.escapeString(value) + '"';
+          value = utils.stringLiteral(value, self.escapeCharacter);
         }
         str = '< ' + value;
       }
@@ -500,7 +505,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
       else {
         if(_.isString(value) && !escapedDate) {
-          value = '"' + utils.escapeString(value) + '"';
+          value = utils.stringLiteral(value, self.escapeCharacter);
         }
         str = '<= ' + value;
       }
@@ -516,7 +521,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
       else {
         if(_.isString(value) && !escapedDate) {
-          value = '"' + utils.escapeString(value) + '"';
+          value = utils.stringLiteral(value, self.escapeCharacter);
         }
         str = '> ' + value;
       }
@@ -532,7 +537,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
       else {
         if(_.isString(value) && !escapedDate) {
-          value = '"' + utils.escapeString(value) + '"';
+          value = utils.stringLiteral(value, self.escapeCharacter);
         }
         str = '>= ' + value;
       }
@@ -545,7 +550,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = 'IS NOT NULL';
       }
       else {
-        // For array values, do a "NOT IN"
+        // For array values, do a 'NOT IN'
         if (Array.isArray(value)) {
 
           if(self.parameterized) {
@@ -568,7 +573,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
             value.forEach(function(val) {
 
               if(_.isString(val)) {
-                val = '"' + utils.escapeString(val) + '"';
+                val = utils.stringLiteral(val, self.escapeCharacter);
               }
 
               str += val + ',';
@@ -586,7 +591,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
           }
           else {
             if(_.isString(value)) {
-              value = '"' + utils.escapeString(value) + '"';
+              value = utils.stringLiteral(value, self.escapeCharacter);
             }
 
             str = '<> ' + value;
@@ -615,7 +620,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' ' + utils.escapeName(value, '"');
+        str = comparator + ' ' + utils.escapeName(value, self.escapeCharacter);
       }
 
       break;
@@ -639,7 +644,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' ' + utils.escapeName('%' + value + '%', '"');
+        str = comparator + ' ' + utils.escapeName('%' + value + '%', self.escapeCharacter);
       }
 
       break;
@@ -663,7 +668,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' ' + utils.escapeName(value + '%', '"');
+        str = comparator + ' ' + utils.escapeName(value + '%', self.escapeCharacter);
       }
 
       break;
@@ -687,7 +692,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' ' + utils.escapeName('%' + value, '"');
+        str = comparator + ' ' + utils.escapeName('%' + value, self.escapeCharacter);
       }
 
       break;
@@ -734,7 +739,7 @@ CriteriaProcessor.prototype.sort = function(options) {
 
   Object.keys(options).forEach(function(key) {
     var direction = options[key] === 1 ? 'ASC' : 'DESC';
-    self.queryString += utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(key, self.escapeCharacter) + ' ' + direction + ', ';
+    self.queryString += utils.escapeName(self.currentTable, self.identifierCharacter) + '.' + utils.escapeName(key, self.identifierCharacter) + ' ' + direction + ', ';
   });
 
   // Remove trailing comma
@@ -754,7 +759,7 @@ CriteriaProcessor.prototype.group = function(options) {
   if(!Array.isArray(options)) options = [options];
 
   options.forEach(function(key) {
-    self.queryString += utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(key, self.escapeCharacter) + ', ';
+    self.queryString += utils.escapeName(self.currentTable, self.identifierCharacter) + '.' + utils.escapeName(key, self.identifierCharacter) + ', ';
   });
 
   // Remove trailing comma

--- a/sequel/lib/utils.js
+++ b/sequel/lib/utils.js
@@ -30,6 +30,25 @@ utils.object.hasOwnProperty = function(obj, prop) {
 
 
 /**
+ * String literal helper function
+ *
+ * Pass in a value and have it wrapped in a string literal.
+ * Saves having self.escapeCharacter littered everywhere
+ *
+ * @param {String} val
+ * @param {String} escapeCharacter
+ * @return {String}
+ * @api public
+ *
+ */
+
+utils.stringLiteral = function stringLiteral(val, escapeCharacter) {
+  var regex = new RegExp(escapeCharacter, 'g');
+  return escapeCharacter+val.replace(regex, '\\'+escapeCharacter)+escapeCharacter;
+}
+
+
+/**
  * Escape Name
  *
  * Wraps a name in quotes to allow reserved
@@ -60,7 +79,10 @@ utils.mapAttributes = function(data, options) {
   var parameterized = options && utils.object.hasOwnProperty(options, 'parameterized') ? options.parameterized : true;
 
   // Get the escape character
-  var escapeCharacter = options && utils.object.hasOwnProperty(options, 'escapeCharacter') ? options.escapeCharacter : '"';
+  var escapeCharacter = options && utils.object.hasOwnProperty(options, 'escapeCharacter') ? options.escapeCharacter : '\'';
+
+  // Get the identifier character
+  var identifierCharacter = options && utils.object.hasOwnProperty(options, 'identifierCharacter') ? options.identifierCharacter : '`';
 
   // Determine if we should escape the inserted characters
   var escapeInserts = options && utils.object.hasOwnProperty(options, 'escapeInserts') ? options.escapeInserts : false;

--- a/sequel/lib/utils.js
+++ b/sequel/lib/utils.js
@@ -88,7 +88,7 @@ utils.mapAttributes = function(data, options) {
   var escapeInserts = options && utils.object.hasOwnProperty(options, 'escapeInserts') ? options.escapeInserts : false;
 
   Object.keys(data).forEach(function(key) {
-    var k = escapeInserts ? (options.escapeCharacter + key + options.escapeCharacter) : key;
+    var k = escapeInserts ? (options.identifierCharacter + key + options.identifierCharacter) : key;
     keys.push(k);
 
     var value = utils.prepareValue(data[key]);

--- a/sequel/select.js
+++ b/sequel/select.js
@@ -16,12 +16,17 @@ var SelectBuilder = module.exports = function(schema, currentTable, queryObject,
 
   this.schema = schema;
   this.currentTable = _.find(_.values(schema), {tableName: currentTable}).identity;
-  this.escapeCharacter = '"';
+  this.escapeCharacter = '\'';
+  this.identifierCharacter = '`';
   this.cast = false;
   this.wlNext = {};
 
   if(options && hop(options, 'escapeCharacter')) {
     this.escapeCharacter = options.escapeCharacter;
+  }
+
+  if (options && hop(options, 'identifierCharacter')) {
+    this.identifierCharacter = options.identifierCharacter;
   }
 
   if(options && hop(options, 'cast')) {
@@ -56,7 +61,7 @@ SelectBuilder.prototype.buildSimpleSelect = function buildSimpleSelect(queryObje
   }
 
   // Escape table name
-  var tableName = utils.escapeName(self.schema[self.currentTable].tableName, self.escapeCharacter);
+  var tableName = utils.escapeName(self.schema[self.currentTable].tableName, self.identifierCharacter);
 
   var selectKeys = [];
   var query = 'SELECT ';
@@ -96,16 +101,16 @@ SelectBuilder.prototype.buildSimpleSelect = function buildSimpleSelect(queryObje
 
     // If there is an alias, set it in the select (used for hasFK associations)
     if(select.alias) {
-      query += utils.escapeName(select.table, self.escapeCharacter) + '.' + utils.escapeName(select.key, self.escapeCharacter) + ' AS ' + self.escapeCharacter + select.alias + '___' + select.key + self.escapeCharacter + ', ';
+      query += utils.escapeName(select.table, self.identifierCharacter) + '.' + utils.escapeName(select.key, self.identifierCharacter) + ' AS ' + self.identifierCharacter + select.alias + '___' + select.key + self.identifierCharacter + ', ';
     }
     else {
-      query += utils.escapeName(select.table, self.escapeCharacter) + '.' + utils.escapeName(select.key, self.escapeCharacter) + ', ';
+      query += utils.escapeName(select.table, self.identifierCharacter) + '.' + utils.escapeName(select.key, self.identifierCharacter) + ', ';
     }
 
   });
 
   // Remove the last comma
-  query = query.slice(0, -2) + ' FROM ' + tableName + ' AS ' + utils.escapeName(self.currentTable, self.escapeCharacter) + ' ';
+  query = query.slice(0, -2) + ' FROM ' + tableName + ' AS ' + utils.escapeName(self.currentTable, self.identifierCharacter) + ' ';
 
   return query;
 };
@@ -131,17 +136,17 @@ SelectBuilder.prototype.processAggregates = function processAggregates(criteria)
 
 
   var query = 'SELECT ';
-  var tableName = utils.escapeName(this.currentTable, this.escapeCharacter);
+  var tableName = utils.escapeName(this.currentTable, this.identifierCharacter);
 
   // Append groupBy columns to select statement
   if(criteria.groupBy) {
     if(criteria.groupBy instanceof Array) {
       criteria.groupBy.forEach(function(opt) {
-        query += tableName + '.' + utils.escapeName(opt, self.escapeCharacter) + ', ';
+        query += tableName + '.' + utils.escapeName(opt, self.identifierCharacter) + ', ';
       });
 
     } else {
-      query += tableName + '.' + utils.escapeName(criteria.groupBy, self.escapeCharacter) + ', ';
+      query += tableName + '.' + utils.escapeName(criteria.groupBy, self.identifierCharacter) + ', ';
     }
   }
 
@@ -150,7 +155,7 @@ SelectBuilder.prototype.processAggregates = function processAggregates(criteria)
     var sum = '';
     if(criteria.sum instanceof Array) {
       criteria.sum.forEach(function(opt) {
-        sum = 'SUM(' + tableName + '.' + utils.escapeName(opt, self.escapeCharacter) + ')';
+        sum = 'SUM(' + tableName + '.' + utils.escapeName(opt, self.identifierCharacter) + ')';
         if(self.cast) {
           sum = 'CAST(' + sum + ' AS float)';
         }
@@ -158,7 +163,7 @@ SelectBuilder.prototype.processAggregates = function processAggregates(criteria)
       });
 
     } else {
-      sum = 'SUM(' + tableName + '.' + utils.escapeName(criteria.sum, self.escapeCharacter) + ')';
+      sum = 'SUM(' + tableName + '.' + utils.escapeName(criteria.sum, self.identifierCharacter) + ')';
       if(self.cast) {
         sum = 'CAST(' + sum + ' AS float)';
       }
@@ -171,14 +176,14 @@ SelectBuilder.prototype.processAggregates = function processAggregates(criteria)
     var avg = '';
     if(criteria.average instanceof Array) {
       criteria.average.forEach(function(opt){
-        avg = 'AVG(' + tableName + '.' + utils.escapeName(opt, self.escapeCharacter) + ')';
+        avg = 'AVG(' + tableName + '.' + utils.escapeName(opt, self.identifierCharacter) + ')';
         if(self.cast) {
           avg = 'CAST( ' + avg + ' AS float)';
         }
         query +=  avg + ' AS ' + opt + ', ';
       });
     } else {
-      avg = 'AVG(' + tableName + '.' + utils.escapeName(criteria.average, self.escapeCharacter) + ')';
+      avg = 'AVG(' + tableName + '.' + utils.escapeName(criteria.average, self.identifierCharacter) + ')';
       if(self.cast) {
         avg = 'CAST( ' + avg + ' AS float)';
       }
@@ -191,11 +196,11 @@ SelectBuilder.prototype.processAggregates = function processAggregates(criteria)
     var max = '';
     if(criteria.max instanceof Array) {
       criteria.max.forEach(function(opt){
-        query += 'MAX(' + tableName + '.' + utils.escapeName(opt, self.escapeCharacter) + ') AS ' + opt + ', ';
+        query += 'MAX(' + tableName + '.' + utils.escapeName(opt, self.identifierCharacter) + ') AS ' + opt + ', ';
       });
 
     } else {
-      query += 'MAX(' + tableName + '.' + utils.escapeName(criteria.max, self.escapeCharacter) + ') AS ' + criteria.max + ', ';
+      query += 'MAX(' + tableName + '.' + utils.escapeName(criteria.max, self.identifierCharacter) + ') AS ' + criteria.max + ', ';
     }
   }
 
@@ -203,11 +208,11 @@ SelectBuilder.prototype.processAggregates = function processAggregates(criteria)
   if (criteria.min) {
     if(criteria.min instanceof Array) {
       criteria.min.forEach(function(opt){
-        query += 'MIN(' + tableName + '.' + utils.escapeName(opt, self.escapeCharacter) + ') AS ' + opt + ', ';
+        query += 'MIN(' + tableName + '.' + utils.escapeName(opt, self.identifierCharacter) + ') AS ' + opt + ', ';
       });
 
     } else {
-      query += 'MIN(' + tableName + '.' + utils.escapeName(criteria.min, self.escapeCharacter) + ') AS ' + criteria.min + ', ';
+      query += 'MIN(' + tableName + '.' + utils.escapeName(criteria.min, self.identifierCharacter) + ') AS ' + criteria.min + ', ';
     }
   }
 
@@ -215,6 +220,6 @@ SelectBuilder.prototype.processAggregates = function processAggregates(criteria)
   query = query.slice(0, -2) + ' ';
 
   // Add FROM clause
-  query += 'FROM ' + utils.escapeName(self.schema[self.currentTable].tableName, self.escapeCharacter) + ' AS ' + tableName + ' ';
+  query += 'FROM ' + utils.escapeName(self.schema[self.currentTable].tableName, self.identifierCharacter) + ' AS ' + tableName + ' ';
   return query;
 };

--- a/sequel/where.js
+++ b/sequel/where.js
@@ -64,6 +64,10 @@ var WhereBuilder = module.exports = function WhereBuilder(schema, currentTable, 
     this.escapeCharacter = options.escapeCharacter;
   }
 
+  if(options && hop(options, 'identifierCharacter')) {
+    this.identifierCharacter = options.identifierCharacter;
+  }
+
   // Add support for WL Next features
   if(options && hop(options, 'wlNext')) {
     this.wlNext = options.wlNext;
@@ -96,9 +100,9 @@ WhereBuilder.prototype.single = function single(queryObject, options) {
     if(strategy === 1) {
 
       // Set outer join logic
-      queryString += 'LEFT OUTER JOIN ' + utils.escapeName(population.child, self.escapeCharacter) + ' AS ' + utils.escapeName('__'+population.alias, self.escapeCharacter) + ' ON ';
-      queryString += utils.escapeName(parentAlias, self.escapeCharacter) + '.' + utils.escapeName(population.parentKey, self.escapeCharacter);
-      queryString += ' = ' + utils.escapeName('__'+population.alias, self.escapeCharacter) + '.' + utils.escapeName(population.childKey, self.escapeCharacter);
+      queryString += 'LEFT OUTER JOIN ' + utils.escapeName(population.child, self.identifierCharacter) + ' AS ' + utils.escapeName('__'+population.alias, self.identifierCharacter) + ' ON ';
+      queryString += utils.escapeName(parentAlias, self.identifierCharacter) + '.' + utils.escapeName(population.parentKey, self.identifierCharacter);
+      queryString += ' = ' + utils.escapeName('__'+population.alias, self.identifierCharacter) + '.' + utils.escapeName(population.childKey, self.identifierCharacter);
 
       addSpace = true;
     }
@@ -139,6 +143,7 @@ WhereBuilder.prototype.single = function single(queryObject, options) {
     parameterized: this.parameterized,
     caseSensitive: this.caseSensitive,
     escapeCharacter: this.escapeCharacter,
+    identifierCharacter: this.identifierCharacter,
     wlNext: this.wlNext
   }, options);
 
@@ -204,6 +209,7 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
         parameterized: self.parameterized,
         caseSensitive: self.caseSensitive,
         escapeCharacter: self.escapeCharacter,
+        identifierCharacter: self.identifierCharacter,
         wlNext: self.wlNext
       }, options);
 
@@ -226,7 +232,7 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
       // Read the queryObject and get back a query string and params
       parsedCriteria = criteriaParser.read(population.criteria);
 
-      queryString = '(SELECT * FROM ' + utils.escapeName(population.child, self.escapeCharacter) + ' AS ' + utils.escapeName(populationAlias, self.escapeCharacter) + ' WHERE ' + utils.escapeName(population.childKey, self.escapeCharacter) + ' = ^?^ ';
+      queryString = '(SELECT * FROM ' + utils.escapeName(population.child, self.identifierCharacter) + ' AS ' + utils.escapeName(populationAlias, self.identifierCharacter) + ' WHERE ' + utils.escapeName(population.childKey, self.identifierCharacter) + ' = ^?^ ';
       if(parsedCriteria) {
 
         // If where criteria was used append an AND clause
@@ -261,6 +267,7 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
         parameterized: self.parameterized,
         caseSensitive: self.caseSensitive,
         escapeCharacter: self.escapeCharacter,
+        identifierCharacter: self.identifierCharacter,
         wlNext: self.wlNext
       }, options);
 
@@ -295,18 +302,18 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
       queryString += '(SELECT ';
       selectKeys.forEach(function(projection) {
         var projectionAlias = _.find(_.values(self.schema), {tableName: projection.table}).identity;
-        queryString += utils.escapeName(projectionAlias, self.escapeCharacter) + '.' + utils.escapeName(projection.key, self.escapeCharacter) + ',';
+        queryString += utils.escapeName(projectionAlias, self.identifierCharacter) + '.' + utils.escapeName(projection.key, self.identifierCharacter) + ',';
       });
 
       // Add an inner join to give us a key to select from
-      queryString += utils.escapeName(stage1.child, self.escapeCharacter) + '.' + utils.escapeName(stage1.childKey, self.escapeCharacter) + ' AS "___' + stage1.childKey + '"';
+      queryString += utils.escapeName(stage1.child, self.identifierCharacter) + '.' + utils.escapeName(stage1.childKey, self.identifierCharacter) + ' AS '+self.identifierCharacter+'___' + stage1.childKey + self.identifierCharacter;
 
-      queryString += ' FROM ' + utils.escapeName(stage2.child, self.escapeCharacter) + ' AS ' + utils.escapeName(stage2ChildAlias, self.escapeCharacter) + ' ';
-      queryString += ' INNER JOIN ' + utils.escapeName(stage1.child, self.escapeCharacter) + ' ON ' + utils.escapeName(stage2.parent, self.escapeCharacter);
-      queryString += '.' + utils.escapeName(stage2.parentKey, self.escapeCharacter) + ' = ' + utils.escapeName(stage2ChildAlias, self.escapeCharacter) + '.' + utils.escapeName(stage2.childKey, self.escapeCharacter);
-      queryString += ' WHERE ' + utils.escapeName(stage2ChildAlias, self.escapeCharacter) + '.' + utils.escapeName(stage2.childKey, self.escapeCharacter) + ' IN ';
-      queryString += '(SELECT ' + utils.escapeName(stage1.child, self.escapeCharacter) + '.' + utils.escapeName(stage2.parentKey, self.escapeCharacter) + ' FROM ';
-      queryString += utils.escapeName(stage1.child, self.escapeCharacter) + ' WHERE ' + utils.escapeName(stage1.child, self.escapeCharacter) + '.' + utils.escapeName(stage1.childKey, self.escapeCharacter);
+      queryString += ' FROM ' + utils.escapeName(stage2.child, self.identifierCharacter) + ' AS ' + utils.escapeName(stage2ChildAlias, self.identifierCharacter) + ' ';
+      queryString += ' INNER JOIN ' + utils.escapeName(stage1.child, self.identifierCharacter) + ' ON ' + utils.escapeName(stage2.parent, self.identifierCharacter);
+      queryString += '.' + utils.escapeName(stage2.parentKey, self.identifierCharacter) + ' = ' + utils.escapeName(stage2ChildAlias, self.identifierCharacter) + '.' + utils.escapeName(stage2.childKey, self.identifierCharacter);
+      queryString += ' WHERE ' + utils.escapeName(stage2ChildAlias, self.identifierCharacter) + '.' + utils.escapeName(stage2.childKey, self.identifierCharacter) + ' IN ';
+      queryString += '(SELECT ' + utils.escapeName(stage1.child, self.identifierCharacter) + '.' + utils.escapeName(stage2.parentKey, self.identifierCharacter) + ' FROM ';
+      queryString += utils.escapeName(stage1.child, self.identifierCharacter) + ' WHERE ' + utils.escapeName(stage1.child, self.identifierCharacter) + '.' + utils.escapeName(stage1.childKey, self.identifierCharacter);
       queryString +=  ' = ^?^ ) ';
 
       if(parsedCriteria) {

--- a/test/options.js
+++ b/test/options.js
@@ -1,7 +1,7 @@
 module.exports = {
   parameterized  : false,
   caseSensitive  : false,
-  escapeCharacter: '`',
+  escapeCharacter: '\'',
   casting        : false,
   canReturnValues: false,
   escapeInserts  : true

--- a/test/queries/complexSelectFilters.js
+++ b/test/queries/complexSelectFilters.js
@@ -64,7 +64,7 @@ module.exports = {
     find  : {
 
       // The queryString we expect to be rendered after calling `Sequel.select()`
-      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz`, `__bat`.`color_g` AS `bat___color_g`, `__bat`.`color_h` AS `bat___color_h`, `__bat`.`color_i` AS `bat___color_i`, `__bat`.`id` AS `bat___id`, `__bat`.`createdAt` AS `bat___createdAt`, `__bat`.`updatedAt` AS `bat___updatedAt` FROM `foo` AS `foo`  LEFT OUTER JOIN `bat` AS `__bat` ON `foo`.`bat` = `__bat`.`id` WHERE `foo`.`bat` = 1 AND `foo`.`baz` IN (1,2,3,4) AND ((LOWER(`foo`.`color`) = "red") OR (LOWER(`foo`.`color`) = "blue") OR (LOWER(`foo`.`color`) = "grey") OR (LOWER(`foo`.`color`) > "111" )) ',
+      queryString    : "SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz`, `__bat`.`color_g` AS `bat___color_g`, `__bat`.`color_h` AS `bat___color_h`, `__bat`.`color_i` AS `bat___color_i`, `__bat`.`id` AS `bat___id`, `__bat`.`createdAt` AS `bat___createdAt`, `__bat`.`updatedAt` AS `bat___updatedAt` FROM `foo` AS `foo`  LEFT OUTER JOIN `bat` AS `__bat` ON `foo`.`bat` = `__bat`.`id` WHERE `foo`.`bat` = 1 AND `foo`.`baz` IN (1,2,3,4) AND ((LOWER(`foo`.`color`) = 'red') OR (LOWER(`foo`.`color`) = 'blue') OR (LOWER(`foo`.`color`) = 'grey') OR (LOWER(`foo`.`color`) > '111' )) ",
 
       // The number of queries that will be returned after calling Sequel.select()
       queriesReturned: 1

--- a/test/queries/simpleSelectWhere.js
+++ b/test/queries/simpleSelectWhere.js
@@ -9,7 +9,7 @@ module.exports = {
   // The query object used to build this query.
   query      : {
     where: {
-      color: 'blue'
+      color: "bl'ue"
     }
   },
 
@@ -30,7 +30,7 @@ module.exports = {
     find  : {
 
       // The queryString we expect to be rendered after calling `Sequel.select()`
-      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) = "blue" ',
+      queryString    : "SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) = 'bl\\'ue' ",
 
       // The number of queries that will be returned after calling Sequel.select()
       queriesReturned: 1


### PR DESCRIPTION
This whole library made use of double quotes. On MySQL servers with ANSI_QUOTES enabled, this was causing the following issue: https://github.com/balderdashy/sails-mysql/issues/195

I've also added a `utils.stringLiteral` method so instead of having `'"'+value+'"'` around the place, it is now a little more tidier.

I've also added an `identifierCharacter` option which defaults to the ` character.

More info on ANSI_QUOTES here: http://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_ansi_quotes
