### PR TITLE
Add integration-tests to waterline-sequel (circleci.com)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,13 @@ language: node_js
 node_js:
   - 0.10
   - 0.11
+services: 
+  - postgresql
+  - mysql
+addons:
+  postgresql: "9.3"
+env:
+  - DB_USER=postgres DB_PASS=''
+before_script:
+  - psql -c 'create database sailspg;' -U postgres
+  - mysql -e 'create database sails_mysql;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,3 @@ language: node_js
 node_js:
   - 0.10
   - 0.11
-services: 
-  - postgresql
-  - mysql
-addons:
-  postgresql: "9.3"
-env:
-  - DB_USER=postgres DB_PASS=''
-before_script:
-  - psql -c 'create database sailspg;' -U postgres
-  - mysql -e 'create database sails_mysql;'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-test: test-unit test-integration
+test: test-unit
 
 test-unit:
 	@NODE_ENV=test ./node_modules/.bin/mocha test/unit test/queries --recursive

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+test: test-unit test-integration
+
+test-unit:
+	@NODE_ENV=test ./node_modules/.bin/mocha test/unit test/queries --recursive
+  
+test-integration:
+	@NODE_ENV=test node test/integration/runnerDispatcher.js

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   services:
     - postgresql
-    - mysq
+    - mysql
   node:
     version: 0.10
   environment:

--- a/circle.yml
+++ b/circle.yml
@@ -2,8 +2,6 @@ machine:
   services:
     - postgresql
     - mysql
-  node:
-    version: 0.10
   environment:
     DB_USER: ubuntu
     DB_PASS: ''

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+machine:
+  services:
+    - postgresql
+    - mysq
+  node:
+    version: 0.10
+  environment:
+    DB_USER: ubuntu
+    DB_PASS: ''
+test:
+  pre:
+    - psql -c 'create database sailspg;' -U postgres
+    - mysql -e 'create database sails_mysql;'
+  override:
+    - make test-integration

--- a/package.json
+++ b/package.json
@@ -13,12 +13,16 @@
     "lodash": "~2.4.1"
   },
   "devDependencies": {
+    "async": "^0.9.0",
     "chai": "^2.1.1",
     "mocha": "^2.2.1",
-    "should": "^5.2.0"
+    "sails-mysql": "git://github.com/balderdashy/sails-mysql",
+    "sails-postgresql": "git://github.com/balderdashy/sails-postgresql",
+    "should": "^5.2.0",
+    "waterline-adapter-tests": "git://github.com/balderdashy/waterline-adapter-tests"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha -b"
+    "test": "make test"
   },
   "main": "sequel/index",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "async": "^0.9.0",
     "chai": "^2.1.1",
     "mocha": "^2.2.1",
+    "npm": "^2.7.4",
     "sails-mysql": "git://github.com/balderdashy/sails-mysql",
     "sails-postgresql": "git://github.com/balderdashy/sails-postgresql",
     "should": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "sails-mysql": "git://github.com/balderdashy/sails-mysql",
     "sails-postgresql": "git://github.com/balderdashy/sails-postgresql",
     "should": "^5.2.0",
-    "waterline-adapter-tests": "git://github.com/balderdashy/waterline-adapter-tests"
+    "waterline-adapter-tests": "^0.10.8"
   },
   "scripts": {
     "test": "make test"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "async": "^0.9.0",
     "chai": "^2.1.1",
+    "jpath": "^0.0.20",
     "mocha": "^2.2.1",
     "npm": "^2.7.4",
     "sails-mysql": "git://github.com/balderdashy/sails-mysql",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "waterline-adapter-tests": "^0.10.8"
   },
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "test-integration": "make test-integration"
   },
   "main": "sequel/index",
   "directories": {

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,25 @@
+Integration tests
+==========================
+[![Build Status](https://travis-ci.org/balderdashy/waterline-sequel.svg?branch=master)](https://travis-ci.org/balderdashy/waterline-sequel)
+
+A set of integration tests that test the SQL official adapters against waterline-sequel edge version: [example](https://travis-ci.org/balderdashy/waterline-sequel/jobs/56144647#L404).
+
+
+## Goals
+
+ * Detect if a change in waterline-sequel breaks any official SQL adapter tests;
+ * Test using the edge version of waterline-sequel and the adapters to ensure the current snapshot of all these are working together and consequently are OK to release;
+ * make it easier for waterline-sequel developers to test changes against the dependents adapters.
+
+
+## What's the difference between these tests and the ones ran by the individual adapters?
+
+The adapters are configured to run their tests against the **stable** version of waterline-sequel. From an adapter point of view, this makes sense since the adapter is only responsible for supporting the stable versions of its dependencies. These tests run against waterline-sequel **edge** version (latest in github) and the objective is to prevent changes in waterline-sequel to accidently break the adapters.
+
+
+## What's the difference between these tests and the waterline-adapter-tests?
+
+The set of integration tests in waterline-adapter-tests test waterline core **edge** against the adapters **edge** versions. These tests tests waterline-sequel **edge** against the adapters **edge** versions using waterline core **stable**. While the former is targeted at waterline core developers the later is targeted waterline-sequel developers.
+
+
+For more details check [PR #32](https://github.com/balderdashy/waterline-sequel/pull/32).

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,6 +1,6 @@
 Integration tests
 ==========================
-[![Build Status](https://travis-ci.org/balderdashy/waterline-sequel.svg?branch=master)](https://travis-ci.org/balderdashy/waterline-sequel)
+[![Circle CI](https://img.shields.io/circleci/project/balderdashy/waterline-sequel/master.svg?style=shield)](https://circleci.com/gh/balderdashy/waterline-sequel/tree/master)
 
 A set of integration tests that test the SQL official adapters against waterline-sequel edge version: [example](https://travis-ci.org/balderdashy/waterline-sequel/jobs/56144647#L404).
 

--- a/test/integration/config/sails-mysql.json
+++ b/test/integration/config/sails-mysql.json
@@ -1,0 +1,11 @@
+{
+  "host": "localhost",
+  "port": 3306,
+  "user": "root",
+  "password": "",
+  "database": "sails_mysql",
+  "pool": true,
+  "connectionLimit": 10,
+  "queueLimit": 0,
+  "waitForConnections": true
+}

--- a/test/integration/config/sails-postgresql.json
+++ b/test/integration/config/sails-postgresql.json
@@ -1,0 +1,9 @@
+{
+  "host": "localhost",
+  "user": "postgres",
+  "password": "",
+  "database": "sailspg",
+  "port": 5432,
+  "schema": true,
+  "ssl": false
+}

--- a/test/integration/customDotReporter.js
+++ b/test/integration/customDotReporter.js
@@ -1,0 +1,66 @@
+/**
+ * Module dependencies.
+ */
+
+var Mocha = require('mocha')
+  , Base = Mocha.reporters.Base
+  , color = Base.color;
+
+// allow to force the use of colors
+Base.useColors = process.env.FORCE_COLORS ? true : Base.useColors;
+
+/**
+ * Expose `Dot`.
+ */
+
+exports = module.exports = Dot;
+
+/**
+ * Initialize a new `Dot` matrix test reporter.
+ *
+ * @param {Runner} runner
+ * @api public
+ */
+
+function Dot(runner) {
+  Base.call(this, runner);
+
+  var self = this
+    , stats = this.stats
+    , width = Base.window.width * .75 | 0
+    , n = -1;
+
+  runner.on('start', function(){
+    process.stdout.write('\n');
+  });
+
+  runner.on('pending', function(test){
+    if (++n % width == 0) process.stdout.write('\n  ');
+    process.stdout.write(color('pending', Base.symbols.dot));
+  });
+
+  runner.on('pass', function(test){
+    if (++n % width == 0) process.stdout.write('\n  ');
+    if ('slow' == test.speed) {
+      process.stdout.write(color('bright yellow', Base.symbols.dot));
+    } else {
+      process.stdout.write(color(test.speed, Base.symbols.dot));
+    }
+  });
+
+  runner.on('fail', function(test, err){
+    if (++n % width == 0) process.stdout.write('\n  ');
+    process.stderr.write(color('fail', Base.symbols.dot));
+  });
+
+  runner.on('end', function(){
+    console.log();
+    self.epilogue();
+  });
+}
+
+/**
+ * Inherit from `Base.prototype`.
+ */
+
+Dot.prototype.__proto__ = Base.prototype;

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -1,0 +1,92 @@
+/**
+ * Test runner dependencies
+ */
+var util = require('util');
+var mocha = require('mocha');
+var customDotReporter = require('./customDotReporter');
+
+var adapterName = process.env.ADAPTER_NAME || process.argv[2];
+var TestRunner = require('waterline-adapter-tests');
+var Adapter = require(adapterName);
+var config = require('./config/' + adapterName + '.json');
+
+
+// Grab targeted interfaces from this adapter's `package.json` file:
+var package = {};
+var interfaces = [];
+try {
+    package = require('../../node_modules/' + adapterName + '/package.json');
+    interfaces = package['waterlineAdapter'].interfaces;
+}
+catch (e) {
+    throw new Error(
+    '\n'+
+    'Could not read supported interfaces from "sails-adapter"."interfaces"'+'\n' +
+    'in this adapter\'s `package.json` file ::' + '\n' +
+    util.inspect(e)
+    );
+}
+
+
+
+
+
+console.info('Testing `' + package.name + '`, a Sails adapter.');
+console.info('Running `waterline-adapter-tests` against ' + interfaces.length + ' interfaces...');
+console.info('( ' + interfaces.join(', ') + ' )');
+console.log();
+console.log('Latest draft of Waterline adapter interface spec:');
+console.info('https://github.com/balderdashy/sails-docs/blob/master/contributing/adapter-specification.md');
+console.log();
+
+
+
+
+/**
+ * Integration Test Runner
+ *
+ * Uses the `waterline-adapter-tests` module to
+ * run mocha tests against the specified interfaces
+ * of the currently-implemented Waterline adapter API.
+ */
+new TestRunner({
+
+    // Load the adapter module.
+    adapter: Adapter,
+
+    // Default adapter config to use.
+    config: config,
+
+    // The set of adapter interfaces to test against.
+    // (grabbed these from this adapter's package.json file above)
+    interfaces: interfaces,
+    
+    // Mocha options
+    // reference: https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically
+    mocha: {
+      reporter: customDotReporter
+    },
+    
+    mochaChainableMethods: {},
+    
+    // Return code != 0 if any test failed
+    failOnError: true
+    
+    // Most databases implement 'semantic' and 'queryable'.
+    // 
+    // As of Sails/Waterline v0.10, the 'associations' interface
+    // is also available.  If you don't implement 'associations',
+    // it will be polyfilled for you by Waterline core.  The core
+    // implementation will always be used for cross-adapter / cross-connection
+    // joins.
+    // 
+    // In future versions of Sails/Waterline, 'queryable' may be also
+    // be polyfilled by core.
+    // 
+    // These polyfilled implementations can usually be further optimized at the
+    // adapter level, since most databases provide optimizations for internal
+    // operations.
+    // 
+    // Full interface reference:
+    // https://github.com/balderdashy/sails-docs/blob/master/contributing/adapter-specification.md
+});

--- a/test/integration/runnerDispatcher.js
+++ b/test/integration/runnerDispatcher.js
@@ -1,0 +1,83 @@
+var exec = require('child_process').exec;
+var async = require('async');
+
+// The adapters being tested
+var adapters = ['sails-postgresql', 'sails-mysql'];
+
+var status = {};
+process.env.FORCE_COLORS = true;
+var exitCode = 0;
+
+console.time('total time elapsed');
+
+var resultTable = "\n";
+resultTable += " --------------------------------------------- \n";
+resultTable += "| adapter          | status  | failed | total |\n";
+resultTable += "|------------------|---------|--------|-------|\n";
+
+async.eachSeries(adapters, function(adapterName, next){
+  status[adapterName] = { failed: 0, total: 0, exitCode: 0 };
+  
+  console.log("\n");
+  console.log("\033[0;34m-------------------------------------------------------------------------------------------\033[0m");
+  console.log("\033[0;34m                                     %s \033[0m", adapterName);
+  console.log("\033[0;34m-------------------------------------------------------------------------------------------\033[0m");
+  console.log();
+  
+  var child = exec('node ./test/integration/runner.js ' + adapterName, { env: process.env });
+  child.stdout.on('data', function(data) {
+    if(isDot(data)) { status[adapterName].total++; }
+    process.stdout.write(data);
+  });
+  child.stderr.on('data', function(data) {
+    if(isDot(data)) { 
+      status[adapterName].total++;
+      status[adapterName].failed++;
+    }
+    process.stdout.write(data);
+  });
+  child.on('close', function(code) {
+    status[adapterName].exitCode = code;
+    var message = code == 0 ? "\033[0;32msuccess\033[0m" : "\033[0;31mfailed \033[0m";
+    resultTable += "| " + padRight(adapterName, 16) 
+      + " | " + message 
+      + " | " + padLeft(status[adapterName].failed, 6) 
+      + " | " + padLeft(status[adapterName].total, 5) 
+      + " |\n";
+    
+    console.log('exit code: ' + code);
+    if(code != 0) { exitCode = code; }
+    next();
+  });
+}, 
+function(){
+  resultTable += " --------------------------------------------- \n";
+  console.log(resultTable);
+  console.timeEnd('total time elapsed');
+  process.exit(exitCode);
+});
+
+
+/**
+ * Aux functions
+ */
+function isDot(data){
+  return data == '․' || (data.length === 10 /*&& data[0] === '\u001b'*/ && data.charAt(5) === '․'.charAt(0));
+}
+
+function padRight(str, padding){
+  var res = "" + str;
+  for(var i=res.length; i<padding; i++){
+    res += ' ';
+  }
+  return res;
+}
+
+function padLeft(str, padding){
+  str = str + "";
+  var pad = "";
+  for(var i=str.length; i<padding; i++){
+    pad += ' ';
+  }
+  return pad + str;
+};

--- a/test/integration/runnerDispatcher.js
+++ b/test/integration/runnerDispatcher.js
@@ -1,62 +1,104 @@
 var exec = require('child_process').exec;
 var async = require('async');
+var npm = require('npm');
 
 // The adapters being tested
 var adapters = ['sails-postgresql', 'sails-mysql'];
 
 var status = {};
+var npmData;
 process.env.FORCE_COLORS = true;
 var exitCode = 0;
 
 console.time('total time elapsed');
 
 var resultTable = "\n";
-resultTable += " --------------------------------------------- \n";
-resultTable += "| adapter          | status  | failed | total |\n";
-resultTable += "|------------------|---------|--------|-------|\n";
+resultTable += " ------------------------------------------------------------------- \n";
+resultTable += "| adapter          | version | status  | failed | total | wl-sequel |\n";
+resultTable += "|------------------|---------|---------|--------|-------|-----------|\n";
 
-async.eachSeries(adapters, function(adapterName, next){
-  status[adapterName] = { failed: 0, total: 0, exitCode: 0 };
-  
-  console.log("\n");
-  console.log("\033[0;34m-------------------------------------------------------------------------------------------\033[0m");
-  console.log("\033[0;34m                                     %s \033[0m", adapterName);
-  console.log("\033[0;34m-------------------------------------------------------------------------------------------\033[0m");
-  console.log();
-  
-  var child = exec('node ./test/integration/runner.js ' + adapterName, { env: process.env });
-  child.stdout.on('data', function(data) {
-    if(isDot(data)) { status[adapterName].total++; }
-    process.stdout.write(data);
+function getNpmDetails(cb){
+  npm.load({ depth: 1 }, function (er) {
+  if (er) return process.exit(1);
+
+  npm.commands.ls('', true, function(err, data){
+    npmData = data;
+    cb(err, data);
   });
-  child.stderr.on('data', function(data) {
-    if(isDot(data)) { 
-      status[adapterName].total++;
-      status[adapterName].failed++;
-    }
-    process.stdout.write(data);
-  });
-  child.on('close', function(code) {
-    status[adapterName].exitCode = code;
-    var message = code == 0 ? "\033[0;32msuccess\033[0m" : "\033[0;31mfailed \033[0m";
-    resultTable += "| " + padRight(adapterName, 16) 
-      + " | " + message 
-      + " | " + padLeft(status[adapterName].failed, 6) 
-      + " | " + padLeft(status[adapterName].total, 5) 
-      + " |\n";
+});
+}
+
+function runTests(cb){
+  async.eachSeries(adapters, function(adapterName, next){
+    status[adapterName] = { failed: 0, total: 0, exitCode: 0 };
     
-    console.log('exit code: ' + code);
-    if(code != 0) { exitCode = code; }
-    next();
-  });
-}, 
-function(){
-  resultTable += " --------------------------------------------- \n";
+    console.log("\n");
+    console.log("\033[0;34m-------------------------------------------------------------------------------------------\033[0m");
+    console.log("\033[0;34m                                     %s \033[0m", adapterName);
+    console.log("\033[0;34m-------------------------------------------------------------------------------------------\033[0m");
+    console.log();
+    
+    var child = exec('node ./test/integration/runner.js ' + adapterName, { env: process.env });
+    child.stdout.on('data', function(data) {
+      if(isDot(data)) { status[adapterName].total++; }
+      process.stdout.write(data);
+    });
+    child.stderr.on('data', function(data) {
+      if(isDot(data)) { 
+        status[adapterName].total++;
+        status[adapterName].failed++;
+      }
+      process.stdout.write(data);
+    });
+    child.on('close', function(code) {
+      status[adapterName].exitCode = code;
+      var message = code == 0 ? "\033[0;32msuccess\033[0m" : "\033[0;31mfailed \033[0m";
+      var adapterNpm = npmData.dependencies[adapterName];
+      var wlSequel = adapterName.indexOf('sql') > 0 ? processVersion(npmData) : "";
+      resultTable += "| " + padRight(adapterName, 16) 
+        + " | " + padRight(processVersion(adapterNpm), 7)
+        + " | " + message 
+        + " | " + padLeft(status[adapterName].failed, 6) 
+        + " | " + padLeft(status[adapterName].total, 5)
+        + " | " + padRight(wlSequel, 9)
+        + " |\n";
+      
+      console.log('exit code: ' + code);
+      if(code != 0) { exitCode = code; }
+      next();
+    });
+  }, 
+  cb);
+}
+
+function printCoreModulesVersions(cb){
+  var coreModules = "\n";
+  coreModules += " ----------------------------------- \n";
+  coreModules += "| Core Modules            | version |\n";
+  coreModules += "|-------------------------|---------|\n";
+  coreModules += getModuleRow('waterline', npmData.dependencies['waterline-adapter-tests'].dependencies['waterline']);
+  coreModules += getModuleRow('waterline-adapter-tests', npmData.dependencies['waterline-adapter-tests']);
+  coreModules += " ----------------------------------- \n";
+  console.log(coreModules);
+  cb();
+}
+
+function getModuleRow(name, module){
+  return "| "+ padRight(name, 23) + " | " 
+    + padRight(processVersion(module), 7) 
+    + " |\n";
+}
+
+
+async.series([getNpmDetails, runTests, printCoreModulesVersions], function(err, res){
+  resultTable += " ------------------------------------------------------------------- \n";
   console.log(resultTable);
   console.timeEnd('total time elapsed');
+  if(err){
+    console.error('Something wrong happened:', err);
+  }
   process.exit(exitCode);
 });
-
 
 /**
  * Aux functions
@@ -81,3 +123,20 @@ function padLeft(str, padding){
   }
   return pad + str;
 };
+
+function processVersion(dependency){
+  if(!dependency) return '';
+  if(dependency._resolved){
+    if(dependency._resolved.indexOf('git') === 0){
+      var parts = dependency._resolved.split('#');
+      return parts[parts.length-1].slice(0, 7);
+    }
+    if(dependency._resolved.indexOf('npmjs.org') >= 0){
+      return dependency.version;
+    }
+  }
+  if(dependency.gitHead){
+    return dependency.gitHead.slice(0, 7);
+  }
+  return dependency.version;
+}


### PR DESCRIPTION
Pretty much what has been said and discussed in #32 but in this version the integration tests run on circleci.com (instead of travis) which allows us for separate badges between unit and integration tests:

[![Circle CI](https://img.shields.io/circleci/project/dmarcelino/waterline-sequel/circleci-integration.svg?style=shield)](https://circleci.com/gh/dmarcelino/waterline-sequel/tree/circleci-integration)

@particlebanana, I'll need you to add waterline-sequel to [circleci.com](http://circleci.com) and configure any github integrations please (it requires an owner). This will give us the best of both worlds! :smiley: 

These tests have the same purpose as those added in balderdashy/waterline-adapter-tests#36 (click for details). These test sails-mysql and sails-postgresql **edge** versions against waterline-sequel **edge** version. They differ from the tests already existing in sails-mysql and sails-postgresql in the sense that those only test against **waterline-sequel stable**. Thus these tests are useful for waterline-sequel developers and to assess their PRs.

First paragraph breakdown in *table format*:

project tests | waterline-sequel version | sails-mysql / sails-postgresql version
-------|----------------------------------|---------------------------------------
sails-mysql | stable | edge
sails-postgresql | stable | edge
waterline-sequel | edge | edge


Example build: https://circleci.com/gh/dmarcelino/waterline-sequel/9