### PR TITLE
Force npm update on CircleCi build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+dependencies:
+  pre:
+    - npm update
 machine:
   services:
     - postgresql


### PR DESCRIPTION
Contrary to travisCI, CircleCI keeps a cache of dependencies which occasionally causes the tests to not run with latest versions. I believe this resulted in us missing that sails-postgres would break a couple of tests when updated to use the latest waterline-sequel version (https://github.com/balderdashy/sails-postgresql/pull/147#issuecomment-94052761).

Lets force an npm update.

If you compare [build #17](https://circleci.com/gh/balderdashy/waterline-sequel/17) to [build #18](https://circleci.com/gh/balderdashy/waterline-sequel/18) (with this change) you can see that the waterline-adapter-tests version changes from `0.10.9` to `0.10.10`.