### PR TITLE
Fix the integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
+ROOT=$(shell pwd)
 
 test: test-unit
 
 test-unit:
+	@echo "\nRunning unit tests..."
 	@NODE_ENV=test ./node_modules/.bin/mocha test/unit test/queries --recursive
   
 test-integration:
+	@echo "\nRunning integration tests..."
+	rm -rf node_modules/sails-postgresql/node_modules/waterline-sequel
+	ln -s $(ROOT) node_modules/sails-postgresql/node_modules/waterline-sequel
+	rm -rf node_modules/sails-mysql/node_modules/waterline-sequel
+	ln -s $(ROOT) node_modules/sails-mysql/node_modules/waterline-sequel
 	@NODE_ENV=test node test/integration/runnerDispatcher.js


### PR DESCRIPTION
I believe I found the reason why the integration tests failed to detect wl-sequel 0.3.0 would break sails-postgresql (#39), the tests were actually using whatever version of wl-sequel sails-postgresql/mysql had in their package.json files, instead of edge.

This change ensures the sails-postgresql/mysql tests run using the latest github version of waterline-sequel.