### PR TITLE
Feature/nested filter alias

### DIFF
--- a/test/queries/simpleSelectNestedFilterAlias.js
+++ b/test/queries/simpleSelectNestedFilterAlias.js
@@ -1,0 +1,45 @@
+/**
+ * This works because waterline-sequel resolves the used alias back to the original key as used in the schema.
+ * That way, the query stays the same, but you have the freedom to use aliases.
+ */
+module.exports = {
+
+  // A description. This is used for display in the test output.
+  description: 'Should construct a nested filter select query using aliased property (using the alias).',
+
+  // The name of the table this query should be ran against.
+  table      : 'oddity',
+
+  // The query object used to build this query.
+  query      : {
+    where: {
+      stubborn : {
+        meta : 'foo'
+      }
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `oddity`.`meta`, `oddity`.`id`, `oddity`.`createdAt`, `oddity`.`updatedAt`, `oddity`.`stubborn`, `oddity`.`bat` FROM `oddity` AS `oddity` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1,
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `oddity`.`meta`, `oddity`.`id`, `oddity`.`createdAt`, `oddity`.`updatedAt`, `oddity`.`stubborn`, `oddity`.`bat` FROM `oddity` AS `oddity`  WHERE `__bar`.`meta` = "foo"  ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    }
+  }
+};

--- a/test/queries/simpleSelectNestedFilterNoAlias.js
+++ b/test/queries/simpleSelectNestedFilterNoAlias.js
@@ -1,0 +1,41 @@
+module.exports = {
+
+  // A description. This is used for display in the test output.
+  description: 'Should construct a nested filter select query using aliased property (not using the alias).',
+
+  // The name of the table this query should be ran against.
+  table      : 'oddity',
+
+  // The query object used to build this query.
+  query      : {
+    where: {
+      bar : {
+        meta : 'foo'
+      }
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `oddity`.`meta`, `oddity`.`id`, `oddity`.`createdAt`, `oddity`.`updatedAt`, `oddity`.`stubborn`, `oddity`.`bat` FROM `oddity` AS `oddity` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1,
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `oddity`.`meta`, `oddity`.`id`, `oddity`.`createdAt`, `oddity`.`updatedAt`, `oddity`.`stubborn`, `oddity`.`bat` FROM `oddity` AS `oddity`  WHERE `__bar`.`meta` = "foo"  ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    }
+  }
+};

--- a/test/queries/simpleSelectObjectFilters.js
+++ b/test/queries/simpleSelectObjectFilters.js
@@ -1,0 +1,39 @@
+module.exports = {
+
+  // A description. This is used for display in the test output.
+  description: 'Should construct a simple select query with an object based where clause',
+
+  // The name of the table this query should be ran against.
+  table      : 'foo',
+
+  // The query object used to build this query.
+  query      : {
+    where: {
+      bat: {'>': 5}
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1,
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE `foo`.`bat` > 5  ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    }
+  }
+};

--- a/test/schema.js
+++ b/test/schema.js
@@ -120,5 +120,44 @@ module.exports = {
         onKey     : "id"
       }
     }
+  },
+  oddity: {
+    connection: ["mysqlServer"],
+    identity  : "oddity",
+    tableName : "oddity",
+    migrate   : "safe",
+    attributes: {
+      meta    : "string",
+      id      : {
+        type         : "integer",
+        autoIncrement: true,
+        primaryKey   : true,
+        unique       : true
+      },
+      createdAt: {
+        type   : "datetime",
+        default: "NOW"
+      },
+      updatedAt: {
+        type   : "datetime",
+        default: "NOW"
+      },
+      bar      : {
+        columnName: "stubborn",
+        type      : "integer",
+        foreignKey: true,
+        references: "bar",
+        on        : "id",
+        onKey     : "id"
+      },
+      bat      : {
+        columnName: "bat",
+        type      : "integer",
+        foreignKey: true,
+        references: "bat",
+        on        : "id",
+        onKey     : "id"
+      }
+    }
   }
 };


### PR DESCRIPTION
Feature/nested filter alias

### Fixed a bug
I've fixed a bug where object based operators on the actual property value caused `undefined` as a value. Basically:

```javascript
var criteria = {
  associationName : {'>' 5}
};
```

killed the query. I've solved this in the easiest way, by checking if the supplied key is an operator.

### Alias based nested filtering
I've added support or alias based filtering. It's minor, but requested by @wayne-o. This feature essentially allows you to supply nested criteria, using the columnName as a key in stead of the property's key.