### PR TITLE
fixed a bug in sails populate that would result in an invalid query string

### DIFF
--- a/sequel/index.js
+++ b/sequel/index.js
@@ -91,7 +91,7 @@ Sequel.prototype.find = function find(currentTable, queryObject) {
 
   whereObject = this.simpleWhere(currentTable, queryObject);
 
-  this.queries[0] += ' ' + whereObject.query ? whereObject.query : '';
+  this.queries[0] += ' ' + (whereObject.query ? whereObject.query : '');
   if (whereObject.values) this.values[0] = whereObject.values;
 
   /**
@@ -130,7 +130,7 @@ Sequel.prototype.count = function count(currentTable, queryObject) {
 
   whereObject = this.simpleWhere(currentTable, queryObject);
 
-  this.queries[0] += ' ' + whereObject.query ? whereObject.query : '';
+  this.queries[0] += ' ' + (whereObject.query ? whereObject.query : '');
   if (whereObject.values) this.values[0] = whereObject.values;
 
   /**

--- a/sequel/index.js
+++ b/sequel/index.js
@@ -91,7 +91,7 @@ Sequel.prototype.find = function find(currentTable, queryObject) {
 
   whereObject = this.simpleWhere(currentTable, queryObject);
 
-  if (whereObject.query) this.queries[0] += ' ' + whereObject.query;
+  this.queries[0] += ' ' + whereObject.query ? whereObject.query : '';
   if (whereObject.values) this.values[0] = whereObject.values;
 
   /**
@@ -130,7 +130,7 @@ Sequel.prototype.count = function count(currentTable, queryObject) {
 
   whereObject = this.simpleWhere(currentTable, queryObject);
 
-  if (whereObject.query) this.queries[0] += ' ' + whereObject.query;
+  this.queries[0] += ' ' + whereObject.query ? whereObject.query : '';
   if (whereObject.values) this.values[0] = whereObject.values;
 
   /**

--- a/sequel/index.js
+++ b/sequel/index.js
@@ -91,8 +91,8 @@ Sequel.prototype.find = function find(currentTable, queryObject) {
 
   whereObject = this.simpleWhere(currentTable, queryObject);
 
-  this.queries[0] += ' ' + whereObject.query;
-  this.values[0] = whereObject.values;
+  if (whereObject.query) this.queries[0] += ' ' + whereObject.query;
+  if (whereObject.values) this.values[0] = whereObject.values;
 
   /**
    * Step 3 - Build out the child query templates.
@@ -130,8 +130,8 @@ Sequel.prototype.count = function count(currentTable, queryObject) {
 
   whereObject = this.simpleWhere(currentTable, queryObject);
 
-  this.queries[0] += ' ' + whereObject.query;
-  this.values[0] = whereObject.values;
+  if (whereObject.query) this.queries[0] += ' ' + whereObject.query;
+  if (whereObject.values) this.values[0] = whereObject.values;
 
   /**
    * Step 3 - Build out the child query templates.


### PR DESCRIPTION
I ran into a problem with cross adapter joins (mysql) in sails, where populate would end up throwing an error because of an invalid query statement.

Although I could not find the root cause for this problem, I introduced a check in waterline-sequel that will stop this from happening. The failing code makes assumptions that there will always a query and values property returned from the `WhereBuilder`, but there seem to exist situations where this is not true.

Here is the example output from sails for the error I'm getting when populating a m:n relation and one side of the relation has no entries, if someone is willing to dig any further into the code (unfortunately the stack trace is really bad, so it is hard for me to go any futher):

```
Executing MySQL query 1:  { query: 
   [ 'SELECT `mailgroup`.`name`, `mailgroup`.`description`, `mailgroup`.`id`, `mailgroup`.`createdAt`, `mailgroup`.`updatedAt` FROM `mailgroup` AS `mailgroup`  undefined',
     '' ],
  values: [ undefined ] }
error: [core] Bootstrap: failed Error (E_UNKNOWN) :: Encountered an unexpected error
: ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'undefined' at line 1
    at Query.Sequence._packetToError (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/sequences/Sequence.js:48:14)
    at Query.ErrorPacket (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/sequences/Query.js:82:18)
    at Protocol._parsePacket (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/Protocol.js:271:23)
    at Parser.write (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/Parser.js:77:12)
    at Protocol.write (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/Protocol.js:39:16)
    at Socket.<anonymous> (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/Connection.js:82:28)
    at Socket.emit (events.js:107:17)
    at readableAddChunk (_stream_readable.js:163:16)
    at Socket.Readable.push (_stream_readable.js:126:10)
    at TCP.onread (net.js:529:20)
    --------------------
    at Protocol._enqueue (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/Protocol.js:135:48)
    at PoolConnection.Connection.query (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/Connection.js:185:25)
    at __FIND__ (/vagrant/node_modules/sails-mysql/lib/adapter.js:836:20)
    at afterwards (/vagrant/node_modules/sails-mysql/lib/connections/spawn.js:84:5)
    at /vagrant/node_modules/sails-mysql/lib/connections/spawn.js:40:7
    at Ping.onPing [as _callback] (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/Pool.js:94:5)
    at Ping.Sequence.end (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/sequences/Sequence.js:96:24)
    at Ping.Sequence.OkPacket (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/sequences/Sequence.js:105:8)
    at Protocol._parsePacket (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/Protocol.js:271:23)
    at Parser.write (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/Parser.js:77:12)
    at Protocol.write (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/protocol/Protocol.js:39:16)
    at Socket.<anonymous> (/vagrant/node_modules/sails-mysql/node_modules/mysql/lib/Connection.js:82:28)
    at Socket.emit (events.js:107:17)
    at readableAddChunk (_stream_readable.js:163:16)
    at Socket.Readable.push (_stream_readable.js:126:10)
    at TCP.onread (net.js:529:20)
```