### PR TITLE
Use tableName instead of identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git://github.com/balderdashy/waterline-sequel.git"
   },
   "dependencies": {
-    "lodash": "~2.4.1"
+    "lodash": "~3.8.0"
   },
   "devDependencies": {
     "async": "^0.9.0",

--- a/sequel/index.js
+++ b/sequel/index.js
@@ -188,7 +188,7 @@ Sequel.prototype.update = function update(currentTable, queryObject, data) {
   };
 
   // Get the attribute identity (as opposed to the table name)
-  var identity = _.find(_.values(this.schema), {tableName: currentTable}).identity;
+  var identity = currentTable;
   // Create the query with the tablename aliased as the identity (in case they are different)
   var query = 'UPDATE ' + utils.escapeName(currentTable, this.escapeCharacter) + ' AS ' + utils.escapeName(identity, this.escapeCharacter) + ' ';
 
@@ -236,7 +236,7 @@ Sequel.prototype.update = function update(currentTable, queryObject, data) {
 Sequel.prototype.destroy = function destroy(currentTable, queryObject) {
 
   // Get the attribute identity (as opposed to the table name)
-  var identity = _.find(_.values(this.schema), {tableName: currentTable}).identity;
+  var identity = currentTable;
 
   var query = 'DELETE ' + (this.declareDeleteAlias ? utils.escapeName(identity, this.escapeCharacter) : '') + ' FROM ' + utils.escapeName(currentTable, this.escapeCharacter) + ' AS ' + utils.escapeName(identity, this.escapeCharacter) + ' ';
 

--- a/sequel/select.js
+++ b/sequel/select.js
@@ -15,7 +15,7 @@ var hop = utils.object.hasOwnProperty;
 var SelectBuilder = module.exports = function(schema, currentTable, queryObject, options) {
 
   this.schema = schema;
-  this.currentTable = _.find(_.values(schema), {tableName: currentTable}).identity;
+  this.currentTable = currentTable;
   this.escapeCharacter = '"';
   this.cast = false;
   this.wlNext = {};
@@ -82,7 +82,7 @@ SelectBuilder.prototype.buildSimpleSelect = function buildSimpleSelect(queryObje
     var population = queryObject.instructions[attr].instructions[0];
 
     // Handle hasFK
-    var childAlias = _.find(_.values(self.schema), {tableName: population.child}).identity;
+    var childAlias = _.find(_.values(self.schema), {tableName: population.child}).tableName;
 
     _.keys(self.schema[childAlias].attributes).forEach(function(key) {
       var schema = self.schema[childAlias].attributes[key];

--- a/sequel/where.js
+++ b/sequel/where.js
@@ -48,7 +48,7 @@ var hop = utils.object.hasOwnProperty;
 var WhereBuilder = module.exports = function WhereBuilder(schema, currentTable, options) {
 
   this.schema = schema;
-  this.currentTable = _.find(_.values(schema), {tableName: currentTable}).identity;
+  this.currentTable = currentTable;
 
   this.wlNext = {};
 
@@ -95,7 +95,7 @@ WhereBuilder.prototype.single = function single(queryObject, options) {
     var population = queryObject.instructions[attr].instructions[0];
     var alias = utils.escapeName(utils.populationAlias(population.alias), self.escapeCharacter);
 
-    var parentAlias = _.find(_.values(self.schema), {tableName: population.parent}).identity;
+    var parentAlias = _.find(_.values(self.schema), {tableName: population.parent}).tableName;
     // Handle hasFK
     if(strategy === 1) {
 
@@ -201,7 +201,7 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
     if(strategy === 2) {
 
       var population = queryObject.instructions[attr].instructions[0];
-      var populationAlias = _.find(_.values(self.schema), {tableName: population.child}).identity;
+      var populationAlias = _.find(_.values(self.schema), {tableName: population.child}).tableName;
 
       // Mixin the parameterized flag into options
       _options = _.assign({
@@ -257,8 +257,8 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
 
       var stage1 = queryObject.instructions[attr].instructions[0];
       var stage2 = queryObject.instructions[attr].instructions[1];
-      stage1ChildAlias = _.find(_.values(self.schema), {tableName: stage1.child}).identity;
-      stage2ChildAlias = _.find(_.values(self.schema), {tableName: stage2.child}).identity;
+      stage1ChildAlias = _.find(_.values(self.schema), {tableName: stage1.child}).tableName;
+      stage2ChildAlias = _.find(_.values(self.schema), {tableName: stage2.child}).tableName;
 
       // Mixin the parameterized flag into options
       _options = _.assign({
@@ -298,7 +298,7 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
 
       queryString += '(SELECT ';
       selectKeys.forEach(function(projection) {
-        var projectionAlias = _.find(_.values(self.schema), {tableName: projection.table}).identity;
+        var projectionAlias = _.find(_.values(self.schema), {tableName: projection.table}).tableName;
         queryString += utils.escapeName(projectionAlias, self.escapeCharacter) + '.' + utils.escapeName(projection.key, self.escapeCharacter) + ',';
       });
 


### PR DESCRIPTION
At this point in the lifecycle identity has no meaning. So assume the schema contains keys that are tableNames. Requires an update to the sql adapters - will PR those after this is published.

This is a breaking change so it will become 0.4.0. I created a branch for 0.3.x so we can push out hotfixes as needed.

With this and the updates to the sql adapters https://github.com/balderdashy/waterline/issues/619 should be taken care of.