### PR TITLE
Make the app not break when the select array is empty

### DIFF
--- a/sequel/select.js
+++ b/sequel/select.js
@@ -104,8 +104,16 @@ SelectBuilder.prototype.buildSimpleSelect = function buildSimpleSelect(queryObje
 
   });
 
-  // Remove the last comma
-  query = query.slice(0, -2) + ' FROM ' + tableName + ' AS ' + utils.escapeName(self.currentTable, self.escapeCharacter) + ' ';
+  // Check if we have any selected columns,
+  // select everything if we don't
+  if(selectKeys.length != 0) {
+    // Remove the last comma
+    query = query.slice(0, -2);
+  } else {
+    query += "*";
+  }
+
+  query += ' FROM ' + tableName + ' AS ' + utils.escapeName(self.currentTable, self.escapeCharacter) + ' ';
 
   return query;
 };

--- a/sequel/where.js
+++ b/sequel/where.js
@@ -189,7 +189,7 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
 
   _.keys(queryObject.instructions).forEach(function(attr) {
 
-    var queryString = '';
+    var queryString = '(SELECT ';
     var criteriaParser;
     var parsedCriteria;
     var childPK;
@@ -245,33 +245,31 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
         attributes.forEach(function(key) {
           var schema = self.schema[population.child].attributes[key] || {};
           if(hop(schema, 'collection')) return;
-            selectKeys.push({ table: population.child, key: schema.columnName || key });
-          });
+          selectKeys.push({ table: population.child, key: schema.columnName || key });
+        });
 
-          selectKeys.forEach(function(select) {
-            // If there is an alias, set it in the select (used for hasFK associations)
-            if(select.alias) {
-              selectColumns += utils.escapeName(select.table, self.escapeCharacter) + '.' + utils.escapeName(select.key, self.escapeCharacter) + ' AS ' + self.escapeCharacter + select.alias + '___' + select.key + self.escapeCharacter + ', ';
-            }
-            else {
-              selectColumns += utils.escapeName(select.table, self.escapeCharacter) + '.' + utils.escapeName(select.key, self.escapeCharacter) + ', ';
-            }
-          });
+        selectKeys.forEach(function(select) {
+          // If there is an alias, set it in the select (used for hasFK associations)
+          if(select.alias) {
+            selectColumns += utils.escapeName(select.table, self.escapeCharacter) + '.' + utils.escapeName(select.key, self.escapeCharacter) + ' AS ' + self.escapeCharacter + select.alias + '___' + select.key + self.escapeCharacter + ', ';
+          }
+          else {
+            selectColumns += utils.escapeName(select.table, self.escapeCharacter) + '.' + utils.escapeName(select.key, self.escapeCharacter) + ', ';
+          }
+        });
 
-          // Remove the last comma
-          selectColumns = selectColumns.slice(0, -2);
-
+        // Remove the last comma
+        selectColumns = selectColumns.slice(0, -2);
       } else {
-          // Select everything if there are no select attributes
-          // If we actually have the attribute but the array is empty,
-          // we will assume that we want everything
-          selectColumns = "*";
+        // Select everything if there are no select attributes
+        // If we actually have the attribute but the array is empty,
+        // we will assume that we want everything
+        selectColumns = '*';
       }
-
       queryString += selectColumns;
 
       queryString += ' FROM ' + utils.escapeName(population.child, self.escapeCharacter) + ' AS ' + utils.escapeName(populationAlias, self.escapeCharacter) + ' WHERE ' + utils.escapeName(population.childKey, self.escapeCharacter) + ' = ^?^ ';
-
+      
       if(parsedCriteria) {
 
         // If where criteria was used append an AND clause


### PR DESCRIPTION
Query concerned:

    var query = {};
    query.select = [];
    Model.find(query).exec(function(err,results) {
        return res.json(results);
    });

Previously, it would make the app return nothing (empty page) since it would slice the query string incorrectly.
I've done changes so that if the select array is empty, it will automatically assume that everything is being selected (as if there was no array).

I presume that the person would like to get everything instead of nothing because it would not really make any logical sense.

The fix could be useful when building the select array dynamically and starting out with an empty array.