### PR TITLE
Fix invalid SQL for empty sort hash

### DIFF
--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -839,11 +839,13 @@ CriteriaProcessor.prototype.skip = function(options) {
  */
 
 CriteriaProcessor.prototype.sort = function(options) {
+  var keys = Object.keys(options);
+  if (!keys.length) { return; }
+  
   var self = this;
-
   this.queryString += ' ORDER BY ';
 
-  Object.keys(options).forEach(function(key) {
+  keys.forEach(function(key) {
     var direction = options[key] === 1 ? 'ASC' : 'DESC';
     self.queryString += utils.escapeName(self.currentTable, self.escapeCharacter) + '.' + utils.escapeName(key, self.escapeCharacter) + ' ' + direction + ', ';
   });

--- a/test/queries/simpleSelectEmptySort.js
+++ b/test/queries/simpleSelectEmptySort.js
@@ -1,7 +1,7 @@
 module.exports = {
 
   // A description. This is used for display in the test output.
-  description: 'Should construct a simple select query with a sort clause',
+  description: 'Should construct a simple select query with an empty sort clause',
 
   // The name of the table this query should be ran against.
   table      : 'foo',

--- a/test/queries/simpleSelectEmptySort.js
+++ b/test/queries/simpleSelectEmptySort.js
@@ -1,0 +1,38 @@
+module.exports = {
+
+  // A description. This is used for display in the test output.
+  description: 'Should construct a simple select query with a sort clause',
+
+  // The name of the table this query should be ran against.
+  table      : 'foo',
+
+  // The query object used to build this query.
+  query      : {
+    where: null,
+    sort: {}
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    }
+  }
+};

--- a/test/queries/simpleSelectSort.js
+++ b/test/queries/simpleSelectSort.js
@@ -1,0 +1,40 @@
+module.exports = {
+
+  // A description. This is used for display in the test output.
+  description: 'Should construct a simple select query with a sort clause',
+
+  // The name of the table this query should be ran against.
+  table      : 'foo',
+
+  // The query object used to build this query.
+  query      : {
+    where: null,
+    sort: {
+      color: 1
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`   ORDER BY `foo`.`color` ASC',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    }
+  }
+};


### PR DESCRIPTION
Hash is valid value for `sort()`. Thus, empty hash is valid value for `sort()` as well. But it produces SQL like that: `... ORDER B`, which certainly is not valid. This PR fixes the issue.