### PR TITLE
Keepin' it simple in the complex query.  Simplify join.

### DIFF
--- a/sequel/where.js
+++ b/sequel/where.js
@@ -308,10 +308,7 @@ WhereBuilder.prototype.complex = function complex(queryObject, options) {
       queryString += ' FROM ' + utils.escapeName(stage2.child, self.escapeCharacter) + ' AS ' + utils.escapeName(stage2ChildAlias, self.escapeCharacter) + ' ';
       queryString += ' INNER JOIN ' + utils.escapeName(stage1.child, self.escapeCharacter) + ' ON ' + utils.escapeName(stage2.parent, self.escapeCharacter);
       queryString += '.' + utils.escapeName(stage2.parentKey, self.escapeCharacter) + ' = ' + utils.escapeName(stage2ChildAlias, self.escapeCharacter) + '.' + utils.escapeName(stage2.childKey, self.escapeCharacter);
-      queryString += ' WHERE ' + utils.escapeName(stage2ChildAlias, self.escapeCharacter) + '.' + utils.escapeName(stage2.childKey, self.escapeCharacter) + ' IN ';
-      queryString += '(SELECT ' + utils.escapeName(stage1.child, self.escapeCharacter) + '.' + utils.escapeName(stage2.parentKey, self.escapeCharacter) + ' FROM ';
-      queryString += utils.escapeName(stage1.child, self.escapeCharacter) + ' WHERE ' + utils.escapeName(stage1.child, self.escapeCharacter) + '.' + utils.escapeName(stage1.childKey, self.escapeCharacter);
-      queryString +=  ' = ^?^ ) ';
+      queryString += ' WHERE ' + utils.escapeName(stage1.child, self.escapeCharacter) + '.' + utils.escapeName(stage1.childKey, self.escapeCharacter) + ' = ^?^ ';
 
       if(parsedCriteria) {
 


### PR DESCRIPTION
Proposed fix for #53.  This seems to fix the issue, and all adapter tests remain passing.  That said, I'd like someone who knows exactly when this query is used and how it is used to make sure this is a valid change.  The query has become much simpler, and (of course) it is not equivalent to the existing query.

Painting in broad strokes, I'm changing
```sql
SELECT files.* FROM files
	INNER JOIN user_has_file ON user_has_file.fileId=files.id
	WHERE files.id IN
		(SELECT user_has_file.fileId FROM user_has_file
			WHERE user_has_file.userId = 1)
	LIMIT 10;
```
to
```sql
SELECT files.* FROM files
	INNER JOIN user_has_file ON user_has_file.fileId=files.id
	WHERE user_has_file.userId = 1
	LIMIT 10;
```

But other criteria can be used with this query, and I'm not sure if that's meant to work in some magical way with the existing query.

This is a hot fix, but I don't want to rush any junk code into production :P. CC waterline-sequelers @particlebanana @RWOverdijk 

**Edit**
Query introduced as part of this commit: https://github.com/balderdashy/waterline-sequel/commit/65376387abbf7340b669f4aa2642d36dc8783e9a.  Maybe @particlebanana recalls the original purpose.