### PR TITLE
Fix to make count query support Limit and Offset

### DIFF
--- a/sequel/index.js
+++ b/sequel/index.js
@@ -119,8 +119,9 @@ Sequel.prototype.count = function count(currentTable, queryObject) {
 
   // Step 1:
   // Build out the Count statements
-  // TO-DO: limit this to a certain column, e.g. id, for performance gains
-  this.queries = ['SELECT COUNT(*) FROM ' + tableName];
+  this.queries = ['SELECT COUNT(*) as count FROM '];
+
+  var subQuery = 'SELECT * FROM ' + tableName;
 
   var whereObject;
   var childQueries;
@@ -128,20 +129,15 @@ Sequel.prototype.count = function count(currentTable, queryObject) {
   var values;
 
   /**
-   * Step 2 - Build out the parent query.
+   * Step 2 - Build out the WHERE part of the query.
    */
 
   whereObject = this.simpleWhere(currentTable, queryObject);
 
-  this.queries[0] += ' ' + whereObject.query;
+  // Append the sub-query to the COUNT so you end up with something that looks like:
+  // SELECT count(*) as count FROM (SELECT * FROM table LIMIT 10 OFFSET 10) AS tableAlias;
+  this.queries[0] += '(SELECT * FROM ' + tableName + ' ' + whereObject.query + ') AS ' + tableName;
   this.values[0] = whereObject.values;
-
-  /**
-   * Step 3 - Build out the child query templates.
-   */
-
-  childQueries = this.complexWhere(currentTable, queryObject);
-  this.queries = this.queries.concat(childQueries);
 
   return {
     query: this.queries,


### PR DESCRIPTION
***Should*** fix up #55. We don't really have integration tests but it uses the same logic as `find` queries so there shouldn't be any issues in the actual query building that don't show up in other queries.

@devinivy let me know if this is what you had in mind. Once merged I'll knock out https://github.com/balderdashy/sails-postgresql/pull/170 and we can update mysql as well.