### PR TITLE
Do not enforce PK sort when table has no PK.

### DIFF
--- a/sequel/where.js
+++ b/sequel/where.js
@@ -125,8 +125,10 @@ WhereBuilder.prototype.single = function single(queryObject, options) {
       childPK = expandedAttr.columnName || attr;
     });
 
-    queryObject.sort = {};
-    queryObject.sort[childPK] = -1;
+    if (childPK) {
+      queryObject.sort = {};
+      queryObject.sort[childPK] = -1;
+    }
   }
 
   // Read the queryObject and get back a query string and params


### PR DESCRIPTION
Intended to fix #23.  Would like a bit of testing on this, if anyone has the time.
