### PR TITLE
Escape like-related queries to disallow breaking literal.

### DIFF
--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -726,7 +726,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' "' + utils.escapeString(value) + '"';
+        str = comparator + ' "' + utils.escapeString(value, true) + '"';
       }
 
       break;
@@ -750,7 +750,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' "%' + utils.escapeString(value) + '%"';
+        str = comparator + ' "%' + utils.escapeString(value, true) + '%"';
       }
 
       break;
@@ -774,7 +774,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' "' + utils.escapeString(value) + '%"';
+        str = comparator + ' "' + utils.escapeString(value, true) + '%"';
       }
 
       break;
@@ -798,7 +798,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' "%' + utils.escapeString(value) + '"';
+        str = comparator + ' "%' + utils.escapeString(value, true) + '"';
       }
 
       break;

--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -726,7 +726,8 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' "' + utils.escapeString(value, true) + '"';
+        // Note that wildcards are not escaped out of like criterion intentionally
+        str = comparator + ' "' + utils.escapeString(value) + '"';
       }
 
       break;

--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -726,7 +726,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' ' + utils.escapeName(value, '"');
+        str = comparator + ' "' + utils.escapeString(value) + '"';
       }
 
       break;
@@ -750,7 +750,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' ' + utils.escapeName('%' + value + '%', '"');
+        str = comparator + ' "%' + utils.escapeString(value) + '%"';
       }
 
       break;
@@ -774,7 +774,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' ' + utils.escapeName(value + '%', '"');
+        str = comparator + ' "' + utils.escapeString(value) + '%"';
       }
 
       break;
@@ -798,7 +798,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
         str = comparator + ' ' + '$' + this.paramCount;
       }
       else {
-        str = comparator + ' ' + utils.escapeName('%' + value, '"');
+        str = comparator + ' "%' + utils.escapeString(value) + '"';
       }
 
       break;
@@ -841,7 +841,7 @@ CriteriaProcessor.prototype.skip = function(options) {
 CriteriaProcessor.prototype.sort = function(options) {
   var keys = Object.keys(options);
   if (!keys.length) { return; }
-  
+
   var self = this;
   this.queryString += ' ORDER BY ';
 

--- a/sequel/lib/utils.js
+++ b/sequel/lib/utils.js
@@ -34,6 +34,12 @@ utils.object.hasOwnProperty = function(obj, prop) {
  *
  * Wraps a name in quotes to allow reserved
  * words as table or column names such as user.
+ *
+ *
+ * NOTE: do not use this method to escape strings in a general-purpose way.
+ * This is intended only to escape schema object (e.g. table and column) names.
+ * Check out utils.escapeString() for other purposes.  No harm in taking a
+ * peek at https://dev.mysql.com/doc/refman/5.7/en/identifiers.html .
  */
 
 utils.escapeName = function escapeName(name, escapeCharacter) {

--- a/sequel/lib/utils.js
+++ b/sequel/lib/utils.js
@@ -139,10 +139,10 @@ utils.prepareValue = function(value) {
  * Escape Strings
  */
 
-utils.escapeString = function(value) {
+utils.escapeString = function(value, forLike) {
   if(!_.isString(value)) return value;
 
-  value = value.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {
+  value = value.replace(/[_%\0\n\r\b\t\\\'\"\x1a]/g, function(s) {
     switch(s) {
       case "\0": return "\\0";
       case "\n": return "\\n";
@@ -150,6 +150,8 @@ utils.escapeString = function(value) {
       case "\b": return "\\b";
       case "\t": return "\\t";
       case "\x1a": return "\\Z";
+      case "%": return forLike ? "\\%" : "%";
+      case "_": return forLike ? "\\_" : "_";
       default: return "\\"+s;
     }
   });

--- a/test/queries/complexSelectFilters.js
+++ b/test/queries/complexSelectFilters.js
@@ -63,10 +63,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz`, `__bat`.`color_g` AS `bat___color_g`, `__bat`.`color_h` AS `bat___color_h`, `__bat`.`color_i` AS `bat___color_i`, `__bat`.`id` AS `bat___id`, `__bat`.`createdAt` AS `bat___createdAt`, `__bat`.`updatedAt` AS `bat___updatedAt` FROM `foo` AS `foo`  LEFT OUTER JOIN `bat` AS `__bat` ON `foo`.`bat` = `__bat`.`id` WHERE `foo`.`bat` = 1 AND `foo`.`baz` IN (1,2,3,4) AND ((LOWER(`foo`.`color`) = "red") OR (LOWER(`foo`.`color`) = "blue") OR (LOWER(`foo`.`color`) = "grey") OR (LOWER(`foo`.`color`) > "111" )) ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/complexSelectNestedFilters.js
+++ b/test/queries/complexSelectNestedFilters.js
@@ -86,10 +86,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz`, `__bat`.`color_g` AS `bat___color_g`, `__bat`.`color_h` AS `bat___color_h`, `__bat`.`color_i` AS `bat___color_i`, `__bat`.`id` AS `bat___id`, `__bat`.`createdAt` AS `bat___createdAt`, `__bat`.`updatedAt` AS `bat___updatedAt` FROM `foo` AS `foo`  LEFT OUTER JOIN `bat` AS `__bat` ON `foo`.`bat` = `__bat`.`id` WHERE ((LOWER(`foo`.`color`) = "red") OR (LOWER(`foo`.`color`) = "blue") OR (LOWER(`foo`.`color`) = "grey") OR (`__bat`.`color_g` = "yellow" ) OR (`__bat`.`color_g` = "blue" )) AND `__bat`.`color_h` = "red" AND ((`__bat`.`color_i` IN ("pink","purple","green")) OR (`__bat`.`color_i` > "black" ) OR (`__bat`.`color_i` = "yellow"))  ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/escaped.js
+++ b/test/queries/escaped.js
@@ -109,6 +109,8 @@ module.exports = [
   },
   {
 
+    // Note that like queries are more permissive,
+    // not escaping wildcard (& and _) characters
     description: 'Should escape like queries.',
 
     table: 'foo',
@@ -136,7 +138,7 @@ module.exports = [
       find: {
 
         // The queryString we expect to be rendered after calling Sequel.find()
-        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "\\\\\\\\\\\\\\" or 1=1; -- \\%\\_"  ',
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "\\\\\\\\\\\\\\" or 1=1; -- %_"  ',
 
         // The number of queries that will be returned after calling Sequel.find()
         queriesReturned: 1

--- a/test/queries/escaped.js
+++ b/test/queries/escaped.js
@@ -1,0 +1,146 @@
+module.exports = [
+  {
+
+    description: 'Should escape startsWith queries.',
+
+    table: 'foo',
+
+    query: {
+      where: {
+        color: { startsWith: '\\\\\\" OR 1=1; -- ' }
+      }
+    },
+
+    // Expected results per query method.
+    expected: {
+
+      // Sequel.select()
+      select: {
+
+        // The queryString we expect to be rendered after calling `Sequel.select()`
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+        // The number of queries that will be returned after calling Sequel.select()
+        queriesReturned: 1,
+      },
+
+      // Sequel.find()
+      find: {
+
+        // The queryString we expect to be rendered after calling Sequel.find()
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "\\\\\\\\\\\\\\" or 1=1; -- %"  ',
+
+        // The number of queries that will be returned after calling Sequel.find()
+        queriesReturned: 1
+      }
+    }
+  },
+  {
+
+    description: 'Should escape endsWith queries.',
+
+    table: 'foo',
+
+    query: {
+      where: {
+        color: { endsWith: '\\\\\\" OR 1=1; -- ' }
+      }
+    },
+
+    // Expected results per query method.
+    expected: {
+
+      // Sequel.select()
+      select: {
+
+        // The queryString we expect to be rendered after calling `Sequel.select()`
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+        // The number of queries that will be returned after calling Sequel.select()
+        queriesReturned: 1,
+      },
+
+      // Sequel.find()
+      find: {
+
+        // The queryString we expect to be rendered after calling Sequel.find()
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "%\\\\\\\\\\\\\\" or 1=1; -- "  ',
+
+        // The number of queries that will be returned after calling Sequel.find()
+        queriesReturned: 1
+      }
+    }
+  },
+  {
+
+    description: 'Should escape contains queries.',
+
+    table: 'foo',
+
+    query: {
+      where: {
+        color: { contains: '\\\\\\" OR 1=1; -- ' }
+      }
+    },
+
+    // Expected results per query method.
+    expected: {
+
+      // Sequel.select()
+      select: {
+
+        // The queryString we expect to be rendered after calling `Sequel.select()`
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+        // The number of queries that will be returned after calling Sequel.select()
+        queriesReturned: 1,
+      },
+
+      // Sequel.find()
+      find: {
+
+        // The queryString we expect to be rendered after calling Sequel.find()
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "%\\\\\\\\\\\\\\" or 1=1; -- %"  ',
+
+        // The number of queries that will be returned after calling Sequel.find()
+        queriesReturned: 1
+      }
+    }
+  },
+  {
+
+    description: 'Should escape like queries.',
+
+    table: 'foo',
+
+    query: {
+      where: {
+        color: { like: '\\\\\\" OR 1=1; -- ' }
+      }
+    },
+
+    // Expected results per query method.
+    expected: {
+
+      // Sequel.select()
+      select: {
+
+        // The queryString we expect to be rendered after calling `Sequel.select()`
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+        // The number of queries that will be returned after calling Sequel.select()
+        queriesReturned: 1,
+      },
+
+      // Sequel.find()
+      find: {
+
+        // The queryString we expect to be rendered after calling Sequel.find()
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "\\\\\\\\\\\\\\" or 1=1; -- "  ',
+
+        // The number of queries that will be returned after calling Sequel.find()
+        queriesReturned: 1
+      }
+    }
+  }
+];

--- a/test/queries/escaped.js
+++ b/test/queries/escaped.js
@@ -7,7 +7,7 @@ module.exports = [
 
     query: {
       where: {
-        color: { startsWith: '\\\\\\" OR 1=1; -- ' }
+        color: { startsWith: '\\\\\\" OR 1=1; -- %_' }
       }
     },
 
@@ -28,7 +28,7 @@ module.exports = [
       find: {
 
         // The queryString we expect to be rendered after calling Sequel.find()
-        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "\\\\\\\\\\\\\\" or 1=1; -- %"  ',
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "\\\\\\\\\\\\\\" or 1=1; -- \\%\\_%"  ',
 
         // The number of queries that will be returned after calling Sequel.find()
         queriesReturned: 1
@@ -43,7 +43,7 @@ module.exports = [
 
     query: {
       where: {
-        color: { endsWith: '\\\\\\" OR 1=1; -- ' }
+        color: { endsWith: '\\\\\\" OR 1=1; -- %_' }
       }
     },
 
@@ -64,7 +64,7 @@ module.exports = [
       find: {
 
         // The queryString we expect to be rendered after calling Sequel.find()
-        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "%\\\\\\\\\\\\\\" or 1=1; -- "  ',
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "%\\\\\\\\\\\\\\" or 1=1; -- \\%\\_"  ',
 
         // The number of queries that will be returned after calling Sequel.find()
         queriesReturned: 1
@@ -79,7 +79,7 @@ module.exports = [
 
     query: {
       where: {
-        color: { contains: '\\\\\\" OR 1=1; -- ' }
+        color: { contains: '\\\\\\" OR 1=1; -- %_' }
       }
     },
 
@@ -100,7 +100,7 @@ module.exports = [
       find: {
 
         // The queryString we expect to be rendered after calling Sequel.find()
-        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "%\\\\\\\\\\\\\\" or 1=1; -- %"  ',
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "%\\\\\\\\\\\\\\" or 1=1; -- \\%\\_%"  ',
 
         // The number of queries that will be returned after calling Sequel.find()
         queriesReturned: 1
@@ -115,7 +115,7 @@ module.exports = [
 
     query: {
       where: {
-        color: { like: '\\\\\\" OR 1=1; -- ' }
+        color: { like: '\\\\\\" OR 1=1; -- %_' }
       }
     },
 
@@ -136,7 +136,7 @@ module.exports = [
       find: {
 
         // The queryString we expect to be rendered after calling Sequel.find()
-        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "\\\\\\\\\\\\\\" or 1=1; -- "  ',
+        queryString: 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) LIKE "\\\\\\\\\\\\\\" or 1=1; -- \\%\\_"  ',
 
         // The number of queries that will be returned after calling Sequel.find()
         queriesReturned: 1

--- a/test/queries/index.js
+++ b/test/queries/index.js
@@ -13,7 +13,7 @@ require("fs").readdirSync(__dirname + '/').forEach(function (file) {
     return;
   }
 
-  queries.push(query);
+  queries = queries.concat(query);
 });
 
 module.exports = queries;

--- a/test/queries/simpleSelect.js
+++ b/test/queries/simpleSelect.js
@@ -25,10 +25,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/simpleSelectEmptySort.js
+++ b/test/queries/simpleSelectEmptySort.js
@@ -28,10 +28,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/simpleSelectNestedFilterAlias.js
+++ b/test/queries/simpleSelectNestedFilterAlias.js
@@ -35,10 +35,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `oddity`.`meta`, `oddity`.`id`, `oddity`.`createdAt`, `oddity`.`updatedAt`, `oddity`.`stubborn`, `oddity`.`bat` FROM `oddity` AS `oddity`  WHERE `__bar`.`meta` = "foo"  ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/simpleSelectNestedFilterNoAlias.js
+++ b/test/queries/simpleSelectNestedFilterNoAlias.js
@@ -31,10 +31,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `oddity`.`meta`, `oddity`.`id`, `oddity`.`createdAt`, `oddity`.`updatedAt`, `oddity`.`stubborn`, `oddity`.`bat` FROM `oddity` AS `oddity`  WHERE `__bar`.`meta` = "foo"  ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/simpleSelectNestedFilters.js
+++ b/test/queries/simpleSelectNestedFilters.js
@@ -55,10 +55,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz`, `__bat`.`color_g` AS `bat___color_g`, `__bat`.`color_h` AS `bat___color_h`, `__bat`.`color_i` AS `bat___color_i`, `__bat`.`id` AS `bat___id`, `__bat`.`createdAt` AS `bat___createdAt`, `__bat`.`updatedAt` AS `bat___updatedAt` FROM `foo` AS `foo`  LEFT OUTER JOIN `bat` AS `__bat` ON `foo`.`bat` = `__bat`.`id` WHERE `__bat`.`color_g` = "yellow"  AND LOWER(`foo`.`color`) = "red" ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/simpleSelectObjectFilters.js
+++ b/test/queries/simpleSelectObjectFilters.js
@@ -29,10 +29,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE `foo`.`bat` > 5  ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/simpleSelectPopulate.js
+++ b/test/queries/simpleSelectPopulate.js
@@ -51,10 +51,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz`, `__bat`.`color_g` AS `bat___color_g`, `__bat`.`color_h` AS `bat___color_h`, `__bat`.`color_i` AS `bat___color_i`, `__bat`.`id` AS `bat___id`, `__bat`.`createdAt` AS `bat___createdAt`, `__bat`.`updatedAt` AS `bat___updatedAt` FROM `foo` AS `foo`  LEFT OUTER JOIN `bat` AS `__bat` ON `foo`.`bat` = `__bat`.`id` ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/simpleSelectSort.js
+++ b/test/queries/simpleSelectSort.js
@@ -30,10 +30,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`   ORDER BY `foo`.`color` ASC',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/simpleSelectWhere.js
+++ b/test/queries/simpleSelectWhere.js
@@ -29,10 +29,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling `Sequel.find()`
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE LOWER(`foo`.`color`) = "blue" ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }

--- a/test/queries/skeleton.js
+++ b/test/queries/skeleton.js
@@ -19,7 +19,7 @@ module.exports = {
     // Sequel.select()
     select: {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling Sequel.select()
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
 
       // The number of queries that will be returned after calling Sequel.select()
@@ -29,10 +29,10 @@ module.exports = {
     // Sequel.find()
     find  : {
 
-      // The queryString we expect to be rendered after calling `Sequel.select()`
+      // The queryString we expect to be rendered after calling Sequel.find()
       queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  ',
 
-      // The number of queries that will be returned after calling Sequel.select()
+      // The number of queries that will be returned after calling Sequel.find()
       queriesReturned: 1
     }
   }


### PR DESCRIPTION
Pretty big bug here for non-parametrized queries, resulting in SQL-injection.  This still needs some work, help appreciated.  `%` and `_` should also be escaped.  In any case, this should contain the bulk of the fix, as well as it can be done in the constraints of waterline-sequel.  Please PR to this branch or create your own PR if you have a much more comprehensive fix.  Related to https://github.com/balderdashy/waterline/issues/1219.

CC @mikermcneil @particlebanana