### PR TITLE
Add support for array-ish `and` clause

### DIFF
--- a/test/queries/simpleSelectAndArray.js
+++ b/test/queries/simpleSelectAndArray.js
@@ -1,0 +1,43 @@
+module.exports = {
+
+  // A description. This is used for display in the test output.
+  description: 'Should construct a simple select query with array-ish AND clause',
+
+  // The name of the table this query should be ran against.
+  table      : 'foo',
+
+  // The query object used to build this query.
+  query      : {
+    where: {
+      and: [
+        {color: 'blue'},
+        {color: 'red'}
+      ]
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.find()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ' +
+      ' WHERE ((LOWER(`foo`.`color`) = "blue") AND (LOWER(`foo`.`color`) = "red")) ',
+
+      // The number of queries that will be returned after calling Sequel.find()
+      queriesReturned: 1
+    }
+  }
+};

--- a/test/queries/simpleSelectDeepAndArray.js
+++ b/test/queries/simpleSelectDeepAndArray.js
@@ -1,0 +1,49 @@
+module.exports = {
+
+  // A description. This is used for display in the test output.
+  description: 'Should construct a simple select query with deep array-ish AND clauses',
+
+  // The name of the table this query should be ran against.
+  table      : 'foo',
+
+  // The query object used to build this query.
+  query      : {
+    where: {
+      and: [
+        {color: 'red'},
+        {and: [
+          {color: 'green'},
+          {and: [
+            {color: 'blue'},
+            {color: 'yellow'}
+          ]}
+        ]}
+      ]
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.find()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ' +
+      ' WHERE ((LOWER(`foo`.`color`) = "red") AND (((LOWER(`foo`.`color`) = "green") AND (((LOWER(`foo`.`color`) = "blue") AND (LOWER(`foo`.`color`) = "yellow")))))) ',
+
+      // The number of queries that will be returned after calling Sequel.find()
+      queriesReturned: 1
+    }
+  }
+};

--- a/test/queries/simpleSelectDeepOr.js
+++ b/test/queries/simpleSelectDeepOr.js
@@ -1,0 +1,49 @@
+module.exports = {
+
+  // A description. This is used for display in the test output.
+  description: 'Should construct a simple select query with deep OR clauses',
+
+  // The name of the table this query should be ran against.
+  table      : 'foo',
+
+  // The query object used to build this query.
+  query      : {
+    where: {
+      or: [
+        {color: 'red'},
+        {or: [
+          {color: 'green'},
+          {or: [
+            {color: 'blue'},
+            {color: 'yellow'}
+          ]}
+        ]}
+      ]
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.find()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ' +
+      ' WHERE ((LOWER(`foo`.`color`) = "red") OR (((LOWER(`foo`.`color`) = "green") OR (((LOWER(`foo`.`color`) = "blue") OR (LOWER(`foo`.`color`) = "yellow")))))) ',
+
+      // The number of queries that will be returned after calling Sequel.find()
+      queriesReturned: 1
+    }
+  }
+};

--- a/test/queries/simpleSelectDeepOrAndAndArray.js
+++ b/test/queries/simpleSelectDeepOrAndAndArray.js
@@ -1,0 +1,59 @@
+module.exports = {
+
+  // A description. This is used for display in the test output.
+  description: 'Should construct a simple select query with mixed deep OR and array-ish AND clauses',
+
+  // The name of the table this query should be ran against.
+  table      : 'foo',
+
+  // The query object used to build this query.
+  query      : {
+    where: {
+      and: [
+        {or: [
+          {color: 'red'},
+          {color: 'green'}
+        ]},
+        {or: [
+          {color: 'blue'},
+          {color: 'yellow'}
+        ]}
+      ],
+      or: [
+        {and: [
+          {color: 'light red'},
+          {color: 'light green'}
+        ]},
+        {and: [
+          {color: 'light blue'},
+          {color: 'light yellow'}
+        ]}
+      ]
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.find()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ' +
+      ' WHERE ((((LOWER(`foo`.`color`) = "red") OR (LOWER(`foo`.`color`) = "green"))) AND (((LOWER(`foo`.`color`) = "blue") OR (LOWER(`foo`.`color`) = "yellow")))) AND ((((LOWER(`foo`.`color`) = "light red") AND (LOWER(`foo`.`color`) = "light green"))) OR (((LOWER(`foo`.`color`) = "light blue") AND (LOWER(`foo`.`color`) = "light yellow")))) ',
+
+      // The number of queries that will be returned after calling Sequel.find()
+      queriesReturned: 1
+    }
+  }
+};

--- a/test/queries/simpleSelectOr.js
+++ b/test/queries/simpleSelectOr.js
@@ -1,0 +1,42 @@
+module.exports = {
+
+  // A description. This is used for display in the test output.
+  description: 'Should construct a simple select query with OR clause',
+
+  // The name of the table this query should be ran against.
+  table      : 'foo',
+
+  // The query object used to build this query.
+  query      : {
+    where: {
+      or: [
+        {color: 'blue'},
+        {color: 'red'}
+      ]
+    }
+  },
+
+  // Expected results per query method.
+  expected   : {
+
+    // Sequel.select()
+    select: {
+
+      // The queryString we expect to be rendered after calling `Sequel.select()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo` ',
+
+      // The number of queries that will be returned after calling Sequel.select()
+      queriesReturned: 1
+    },
+
+    // Sequel.find()
+    find  : {
+
+      // The queryString we expect to be rendered after calling `Sequel.find()`
+      queryString    : 'SELECT `foo`.`color`, `foo`.`id`, `foo`.`createdAt`, `foo`.`updatedAt`, `foo`.`bar`, `foo`.`bat`, `foo`.`baz` FROM `foo` AS `foo`  WHERE ((LOWER(`foo`.`color`) = "blue") OR (LOWER(`foo`.`color`) = "red")) ',
+
+      // The number of queries that will be returned after calling Sequel.find()
+      queriesReturned: 1
+    }
+  }
+};


### PR DESCRIPTION
...which also gives you a support for nested and mixed `and` and `or` clauses. Like these:

``` javascript
// WHERE color="blue" AND color="red"
Pencil.find({
  where: {
    and: [
      {color: 'blue'},
      {color: 'red'}
    ]
  }
});

// WHERE color="red" AND (color="green" AND color="blue")
Pencil.find({
  where: {
    color: 'red',
    and: [
      {color: 'green'},
      {color: 'blue'}
    ]
  }
});

// WHERE color="red" AND (color="green" AND (color="blue" AND color="yellow"))
Pencil.find({
  where: {
    and: [
      {color: 'red'},
      {
        and: [
          {color: 'green'},
          {
            and: [
              {color: 'blue'},
              {color: 'yellow'}
            ]
          }
        ]
      }
    ]
  }
});

// WHERE (color="red" OR color="green") AND (color="blue" OR color="yellow")
Pencil.find({
  where: {
    and: [
      {
        or: [
          {color: 'red'},
          {color: 'green'}
        ]
      },
      {
        or: [
          {color: 'blue'},
          {color: 'yellow'}
        ]
      }
    ]
  }
});

// WHERE (color="red" AND color="green") OR (color="blue" AND color="yellow")
Pencil.find({
  where: {
    or: [
      {
        and: [
          {color: 'red'},
          {color: 'green'}
        ]
      },
      {
        and: [
          {color: 'blue'},
          {color: 'yellow'}
        ]
      }
    ]
  }
});
```

Effectively closes https://github.com/balderdashy/waterline/issues/828
