### PR TITLE
Throw an error if the operator is unknown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
+.PHONY: test test-unit install test-integration
+
 ROOT=$(shell pwd)
+
+install:
+	npm install
 
 test: test-unit
 

--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -830,6 +830,11 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
 
       break;
+
+    default:
+      var err = new Error('Unknown filtering operator: "' + key + "\". Should be 'startsWith', '>', 'contains' or similar");
+      err.operator = key;
+      throw err;
   }
 
   // Bump paramCount

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -82,6 +82,14 @@ describe('Sequel', function () {
     });
   });
 
+  describe('queries with an unknown operator', function () {
+    it('throws an error when the operator is unknown', function() {
+      var sequel = new Sequel(schema);
+      assert.throws(sequel.find.bind(sequel, 'bar', { id: { 'in': [ 1, 2 ] } }),
+        Error, "Unknown filtering operator: \"in\". Should be 'startsWith', '>', 'contains' or similar");
+    });
+  });
+
   describe('.find() with schema name', function () {
     var _options = _.extend({}, options, {schemaName: {'foo':'myschema','oddity':'anotherschema','bat':'public'}});
     // Loop through the query objects and test them against the `.find()` method.
@@ -99,5 +107,5 @@ describe('Sequel', function () {
         done();
       });
     });
-  });  
+  });
 });


### PR DESCRIPTION
Previously passing a query with an unknown operator would place the word
"undefined" in the SQL query:

```javascript
sequel.find('users', { balance: { 'in': [ 1, 2 ] } });
```

```sql
'SELECT "users"."id", "users"."email", "users"."balance", "users"."pickupCount"
FROM "users" AS "users"  "users"."balance" undefined  '
```

(Valid operators are things like 'contains', 'startsWith', 'endsWith', '>'.)

This happens because we define the var `str` to be undefined, never set it, and
then append it to the query string.

Instead, immediately throw an error when an unknown key gets passed to
Waterline, which should help diagnose these problems going forward (instead of
forcing us to parse a Postgres syntax error).

Cherry-picked from https://github.com/Shyp/waterline-sequel/pull/6. Fixes #86.