### PR TITLE
Handling Oracle's missing ILIKE operator

### DIFF
--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -574,7 +574,7 @@ CriteriaProcessor.prototype.process = function process(parent, value, combinator
   }
 
   // Add support for overriding case sensitivity with WL Next features
-  if(hop(isWLNextForceLike(this.wlNext))) {
+  if(isWLNextForceLike(this.wlNext)) {
     caseSensitive = true;
   }
 

--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -228,7 +228,8 @@ CriteriaProcessor.prototype.like = function like(val) {
     var comparator = self.caseSensitive ? 'ILIKE' : 'LIKE';
 
     // Override comparator with WL Next features
-    if(isWLNextForceLike(self.wlNext)) {
+    if(
+      (self.wlNext)) {
       comparator = 'LIKE';
     }
 
@@ -574,7 +575,7 @@ CriteriaProcessor.prototype.process = function process(parent, value, combinator
   }
 
   // Add support for overriding case sensitivity with WL Next features
-  if(hop(isWLNextForceLike(this.wlNext)) {
+  if(hop(isWLNextForceLike(this.wlNext))) {
     caseSensitive = true;
   }
 

--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -228,7 +228,7 @@ CriteriaProcessor.prototype.like = function like(val) {
     var comparator = self.caseSensitive ? 'ILIKE' : 'LIKE';
 
     // Override comparator with WL Next features
-    if(hop(self.wlNext, 'caseSensitive') && self.wlNext.caseSensitive) {
+    if(isWLNextForceLike(self.wlNext)) {
       comparator = 'LIKE';
     }
 
@@ -257,7 +257,7 @@ CriteriaProcessor.prototype.and = function and(key, val) {
   }
 
   // Override case sensitive with WL Next features
-  if(hop(this.wlNext, 'caseSensitive') && this.wlNext.caseSensitive) {
+  if(isWLNextForceLike(this.wlNext)) {
     caseSensitive = true;
   }
 
@@ -318,7 +318,7 @@ CriteriaProcessor.prototype._in = function _in(key, val) {
   }
 
   // Add support for overriding case sensitivity with WL Next features
-  if(hop(self.wlNext, 'caseSensitive') && self.wlNext.caseSensitive) {
+  if(isWLNextForceLike(self.wlNext)) {
     caseSensitivity = true;
   }
 
@@ -574,7 +574,7 @@ CriteriaProcessor.prototype.process = function process(parent, value, combinator
   }
 
   // Add support for overriding case sensitivity with WL Next features
-  if(hop(this.wlNext, 'caseSensitive') && this.wlNext.caseSensitive) {
+  if(hop(isWLNextForceLike(this.wlNext)) {
     caseSensitive = true;
   }
 
@@ -744,7 +744,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
 
       // Override comparator with WL Next features
-      if(hop(self.wlNext, 'caseSensitive') && self.wlNext.caseSensitive) {
+      if(isWLNextForceLike(self.wlNext)) {
         comparator = 'LIKE';
       }
 
@@ -769,7 +769,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
 
       // Override comparator with WL Next features
-      if(hop(self.wlNext, 'caseSensitive') && self.wlNext.caseSensitive) {
+      if(isWLNextForceLike(self.wlNext)) {
         comparator = 'LIKE';
       }
 
@@ -793,7 +793,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
 
       // Override comparator with WL Next features
-      if(hop(self.wlNext, 'caseSensitive') && self.wlNext.caseSensitive) {
+      if(isWLNextForceLike(self.wlNext)) {
         comparator = 'LIKE';
       }
 
@@ -817,7 +817,7 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
 
       // Override comparator with WL Next features
-      if(hop(self.wlNext, 'caseSensitive') && self.wlNext.caseSensitive) {
+      if(isWLNextForceLike(self.wlNext)) {
         comparator = 'LIKE';
       }
 
@@ -913,3 +913,12 @@ CriteriaProcessor.prototype.group = function(options) {
   // Remove trailing comma
   this.queryString = this.queryString.slice(0, -2);
 };
+
+function isWLNextForceLike(wlNext) {
+  return isWlNextAttributeTrue(wlNext, 'caseSensitive')
+      || isWlNextAttributeTrue(wlNext, 'forceLike');
+}
+
+function isWlNextAttributeTrue(wlNext, attribute) {
+  return hop(wlNext, attribute) && true === wlNext[attribute];
+}

--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -228,8 +228,7 @@ CriteriaProcessor.prototype.like = function like(val) {
     var comparator = self.caseSensitive ? 'ILIKE' : 'LIKE';
 
     // Override comparator with WL Next features
-    if(
-      (self.wlNext)) {
+    if(isWLNextForceLike(self.wlNext)) {
       comparator = 'LIKE';
     }
 


### PR DESCRIPTION
Oracle does not have the ILIKE operator, which makes the pure usage of `wlNext.caseSensitive` flag not possible.

Here's what I found out and what my change is based on. Setting `wlNext.caseSensitive: true` produces a plain LIKE query, which makes perfect sense.

Setting `wlNext.caseSensitive: false` produces an ILIKE query. This case throws an error when using with Oracle, because Oracle does not have the ILIKE operator.

My solution above was twofold. First, I fixed the DRY violation on the `wlNext.caseSensitive` flag checking. Second, I added a new flag `wlNext.forceLike` with which one can indicate that the database requires LIKE to be used, instead of ILIKE.